### PR TITLE
Make FormatParser parse bytes instead of str

### DIFF
--- a/src/source/format.rs
+++ b/src/source/format.rs
@@ -5,7 +5,7 @@ use super::SourceError;
 pub trait FormatParser: std::fmt::Debug {
     type Output: IntoConfigElement + std::fmt::Debug + Sized;
 
-    fn parse(buffer: &str) -> Result<Self::Output, SourceError>;
+    fn parse(buffer: &[u8]) -> Result<Self::Output, SourceError>;
 }
 
 #[cfg(feature = "json")]
@@ -16,8 +16,8 @@ pub struct JsonFormatParser;
 impl FormatParser for JsonFormatParser {
     type Output = serde_json::Value;
 
-    fn parse(buffer: &str) -> Result<Self::Output, SourceError> {
-        serde_json::from_str(buffer).map_err(SourceError::JsonParserError)
+    fn parse(buffer: &[u8]) -> Result<Self::Output, SourceError> {
+        serde_json::from_slice(buffer).map_err(SourceError::JsonParserError)
     }
 }
 
@@ -29,7 +29,7 @@ pub struct TomlFormatParser;
 impl FormatParser for TomlFormatParser {
     type Output = toml::Value;
 
-    fn parse(buffer: &str) -> Result<Self::Output, SourceError> {
-        toml::from_str(buffer).map_err(SourceError::TomlParserError)
+    fn parse(buffer: &[u8]) -> Result<Self::Output, SourceError> {
+        toml::from_slice(buffer).map_err(SourceError::TomlParserError)
     }
 }

--- a/src/source/string.rs
+++ b/src/source/string.rs
@@ -27,7 +27,7 @@ where
     SourceError: From<<<P as FormatParser>::Output as IntoConfigElement>::Error>,
 {
     fn load(&self) -> Result<ConfigObject, SourceError> {
-        let element = P::parse(&self.source)?;
+        let element = P::parse(self.source.as_bytes())?;
         let element = element.into_config_element()?;
 
         let desc = ConfigSourceDescription::Custom("String".to_string());


### PR DESCRIPTION
The format parsing should work on bytes rather than `str`.