### PR TITLE
Format independence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ futures = { version = "0.3", optional = true }
 serde_json = { version = "1.0.2", optional = true }
 toml = { version = "0.5", optional = true }
 tokio = { version = "1", optional = true, features = ["fs"] }
+static_assertions = "1.1.0"
+downcast-rs = "1.2.0"
 
 [features]
 default = ["async", "json", "toml"]

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -64,7 +64,7 @@ impl Config {
     ///     // ...
     /// # ;
     /// ```
-    pub fn get<A>(&self, accessor: A) -> Result<Option<&ConfigElement>, ConfigError>
+    pub fn get<A>(&self, accessor: A) -> Result<Option<&dyn ConfigElement>, ConfigError>
     where
         A: ParsableAccessor,
     {
@@ -78,9 +78,31 @@ impl Config {
     pub fn get_with_accessor(
         &self,
         mut accessor: Accessor,
-    ) -> Result<Option<&ConfigElement>, ConfigError> {
+    ) -> Result<Option<&dyn ConfigElement>, ConfigError> {
         for layer in self.layers.iter().rev() {
             if let Some(value) = layer.get(&mut accessor)? {
+                return Ok(Some(value));
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub fn get_as<A, T>(&self, accessor: A) -> Result<Option<&T>, ConfigError>
+    where
+        A: ParsableAccessor,
+        T: ConfigElement,
+    {
+        let accessor = accessor.parse()?;
+        self.get_with_accessor_as::<T>(accessor)
+    }
+
+    pub fn get_with_accessor_as<T>(&self, mut accessor: Accessor) -> Result<Option<&T>, ConfigError>
+    where
+        T: ConfigElement,
+    {
+        for layer in self.layers.iter().rev() {
+            if let Some(value) = layer.get_as::<T>(&mut accessor)? {
                 return Ok(Some(value));
             }
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,14 +14,12 @@ pub use crate::config::error::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::element::ConfigElement;
-    use crate::element::IntoConfigElement;
 
     #[test]
     fn test_compile_loading() {
         let _c = Config::builder()
             .load(Box::new(crate::source::test_source::TestSource(
-                ConfigElement::Null,
+                toml::Value::String("".to_string()),
             )))
             .build()
             .unwrap();
@@ -38,9 +36,7 @@ mod tests {
         .unwrap();
 
         let _c = Config::builder()
-            .load(Box::new(crate::source::test_source::TestSource(
-                json.into_config_element().unwrap(),
-            )))
+            .load(Box::new(crate::source::test_source::TestSource(json)))
             .build()
             .unwrap();
     }
@@ -55,7 +51,7 @@ mod tests {
         )
         .unwrap();
 
-        let source = crate::source::test_source::TestSource(json.into_config_element().unwrap());
+        let source = crate::source::test_source::TestSource(json);
 
         let c = Config::builder().load(Box::new(source)).build().unwrap();
 
@@ -64,10 +60,8 @@ mod tests {
         let r = r.unwrap();
         assert!(r.is_some());
         let r = r.unwrap();
-        match r {
-            ConfigElement::Str(s) => assert_eq!(s, "value"),
-            _ => panic!(),
-        }
+        assert!(r.is_str());
+        assert_eq!(r.as_str().unwrap(), "value");
     }
 
     #[test]
@@ -87,8 +81,8 @@ mod tests {
         )
         .unwrap();
 
-        let source1 = crate::source::test_source::TestSource(json1.into_config_element().unwrap());
-        let source2 = crate::source::test_source::TestSource(json2.into_config_element().unwrap());
+        let source1 = crate::source::test_source::TestSource(json1);
+        let source2 = crate::source::test_source::TestSource(json2);
 
         let c = Config::builder()
             .load(Box::new(source1))
@@ -101,20 +95,16 @@ mod tests {
         let r = r.unwrap();
         assert!(r.is_some());
         let r = r.unwrap();
-        match r {
-            ConfigElement::Str(s) => assert_eq!(s, "value2"),
-            _ => panic!(),
-        }
+        assert!(r.is_str());
+        assert_eq!(r.as_str().unwrap(), "value2");
 
         let r = c.get("key2");
         assert!(r.is_ok());
         let r = r.unwrap();
         assert!(r.is_some());
         let r = r.unwrap();
-        match r {
-            ConfigElement::Str(s) => assert_eq!(s, "value3"),
-            _ => panic!(),
-        }
+        assert!(r.is_str());
+        assert_eq!(r.as_str().unwrap(), "value3");
     }
 
     #[test]
@@ -135,8 +125,8 @@ mod tests {
         )
         .unwrap();
 
-        let source1 = crate::source::test_source::TestSource(json.into_config_element().unwrap());
-        let source2 = crate::source::test_source::TestSource(toml.into_config_element().unwrap());
+        let source1 = crate::source::test_source::TestSource(json);
+        let source2 = crate::source::test_source::TestSource(toml);
 
         let c = Config::builder()
             .load(Box::new(source1))
@@ -149,19 +139,15 @@ mod tests {
         let r = r.unwrap();
         assert!(r.is_some());
         let r = r.unwrap();
-        match r {
-            ConfigElement::Str(s) => assert_eq!(s, "value2"),
-            _ => panic!(),
-        }
+        assert!(r.is_str());
+        assert_eq!(r.as_str().unwrap(), "value2");
 
         let r = c.get("key2");
         assert!(r.is_ok());
         let r = r.unwrap();
         assert!(r.is_some());
         let r = r.unwrap();
-        match r {
-            ConfigElement::Str(s) => assert_eq!(s, "value3"),
-            _ => panic!(),
-        }
+        assert!(r.is_str());
+        assert_eq!(r.as_str().unwrap(), "value3");
     }
 }

--- a/src/element/json.rs
+++ b/src/element/json.rs
@@ -1,58 +1,175 @@
-use std::collections::HashMap;
-
 use crate::element::ConfigElement;
-use crate::element::IntoConfigElement;
 
-#[derive(Debug, thiserror::Error)]
-pub enum JsonIntoConfigElementError {}
+use serde_json::Value;
 
-impl IntoConfigElement for serde_json::Value {
-    type Error = JsonIntoConfigElementError;
+use super::{ConfigElementListType, ConfigElementMapType};
 
-    fn into_config_element(self) -> Result<ConfigElement, Self::Error> {
-        match self {
-            serde_json::Value::Null => Ok(ConfigElement::Null),
-            serde_json::Value::Bool(b) => Ok(ConfigElement::Bool(b)),
-            serde_json::Value::Number(num) => num
-                .as_i64()
-                .map(ConfigElement::I64)
-                .or_else(|| num.as_u64().map(ConfigElement::U64))
-                .or_else(|| num.as_f64().map(ConfigElement::F64))
-                .ok_or_else(|| unimplemented!()),
-            serde_json::Value::String(s) => Ok(ConfigElement::Str(s)),
-            serde_json::Value::Array(vec) => vec
-                .into_iter()
-                .map(|v| v.into_config_element())
-                .collect::<Result<Vec<_>, Self::Error>>()
-                .map(ConfigElement::List),
-            serde_json::Value::Object(obj) => obj
-                .into_iter()
-                .map(|(k, v)| v.into_config_element().map(|v| (k.to_string(), v)))
-                .collect::<Result<HashMap<String, ConfigElement>, JsonIntoConfigElementError>>()
-                .map(ConfigElement::Map),
-        }
+impl ConfigElement for Value {
+    fn is_null(&self) -> bool {
+        std::matches!(self, Value::Null)
+    }
+
+    fn is_bool(&self) -> bool {
+        std::matches!(self, Value::Bool(_))
+    }
+
+    fn is_i8(&self) -> bool {
+        self.as_i64().filter(|i| *i < (i8::MAX as i64)).is_some()
+    }
+
+    fn is_i16(&self) -> bool {
+        self.as_i64().filter(|i| *i < (i16::MAX as i64)).is_some()
+    }
+
+    fn is_i32(&self) -> bool {
+        self.as_i64().filter(|i| *i < (i32::MAX as i64)).is_some()
+    }
+
+    fn is_i64(&self) -> bool {
+        self.as_i64().filter(|i| *i < (i64::MAX as i64)).is_some()
+    }
+
+    fn is_u8(&self) -> bool {
+        self.as_i64()
+            .filter(|i| i.is_positive())
+            .filter(|i| *i < (u8::MAX as i64))
+            .is_some()
+    }
+
+    fn is_u16(&self) -> bool {
+        self.as_i64()
+            .filter(|i| i.is_positive())
+            .filter(|i| *i < (u16::MAX as i64))
+            .is_some()
+    }
+
+    fn is_u32(&self) -> bool {
+        self.as_i64()
+            .filter(|i| i.is_positive())
+            .filter(|i| *i < (u32::MAX as i64))
+            .is_some()
+    }
+
+    fn is_u64(&self) -> bool {
+        self.as_i64()
+            .filter(|i| i.is_positive())
+            .filter(|i| *i < (u64::MAX as i64))
+            .is_some()
+    }
+
+    fn is_f32(&self) -> bool {
+        self.is_f64()
+            && self
+                .as_f64()
+                .filter(|f| *f < (f32::MAX as f64) && *f > (f32::MIN as f64))
+                .is_some()
+    }
+
+    fn is_f64(&self) -> bool {
+        self.is_f64()
+    }
+
+    fn is_str(&self) -> bool {
+        std::matches!(self, Value::String(_))
+    }
+
+    fn is_list(&self) -> bool {
+        std::matches!(self, Value::Array(_))
+    }
+
+    fn is_map(&self) -> bool {
+        std::matches!(self, Value::Object(_))
+    }
+
+    fn as_bool(&self) -> Option<bool> {
+        self.as_bool()
+    }
+
+    fn as_i8(&self) -> Option<i8> {
+        self.as_i64()
+            .filter(|i| (*i < (i8::MAX as i64)))
+            .map(|i| i as i8)
+    }
+
+    fn as_i16(&self) -> Option<i16> {
+        self.as_i64()
+            .filter(|i| (*i < (i16::MAX as i64)))
+            .map(|i| i as i16)
+    }
+
+    fn as_i32(&self) -> Option<i32> {
+        self.as_i64()
+            .filter(|i| (*i < (i32::MAX as i64)))
+            .map(|i| i as i32)
+    }
+
+    fn as_i64(&self) -> Option<i64> {
+        self.as_i64()
+    }
+
+    fn as_u8(&self) -> Option<u8> {
+        self.as_i64()
+            .filter(|i| i.is_positive())
+            .filter(|i| (*i < (u8::MAX as i64)))
+            .map(|i| i as u8)
+    }
+
+    fn as_u16(&self) -> Option<u16> {
+        self.as_i64()
+            .filter(|i| i.is_positive())
+            .filter(|i| (*i < (u16::MAX as i64)))
+            .map(|i| i as u16)
+    }
+
+    fn as_u32(&self) -> Option<u32> {
+        self.as_i64()
+            .filter(|i| i.is_positive())
+            .filter(|i| (*i < (u32::MAX as i64)))
+            .map(|i| i as u32)
+    }
+
+    fn as_u64(&self) -> Option<u64> {
+        self.as_i64()
+            .filter(|i| i.is_positive())
+            .filter(|i| (*i < (u64::MAX as i64)))
+            .map(|i| i as u64)
+    }
+
+    fn as_f32(&self) -> Option<f32> {
+        self.as_f64()
+            .filter(|f| *f < (f32::MAX as f64) && *f > (f32::MIN as f64))
+            .map(|f| f as f32)
+    }
+
+    fn as_f64(&self) -> Option<f64> {
+        self.as_f64()
+    }
+
+    fn as_str(&self) -> Option<&str> {
+        self.as_str()
+    }
+
+    fn as_list(&self) -> Option<&dyn ConfigElementListType> {
+        self.as_array().map(|a| a as &dyn ConfigElementListType)
+    }
+
+    fn as_map(&self) -> Option<&dyn ConfigElementMapType> {
+        self.as_object().map(|t| t as &dyn ConfigElementMapType)
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::element::ConfigElement;
+impl ConfigElementMapType for serde_json::Map<String, serde_json::Value> {
+    fn get(&self, key: &str) -> Option<&dyn ConfigElement> {
+        serde_json::Map::get(self, key).map(|t| t as &dyn ConfigElement)
+    }
 
-    #[test]
-    fn deser_json_1() {
-        let s = r#"
-            { "key": "value" }
-        "#;
+    fn keys(&self) -> Vec<String> {
+        serde_json::Map::keys(self).map(String::to_owned).collect()
+    }
 
-        let e: ConfigElement = serde_json::from_str(s).unwrap();
-        match e {
-            ConfigElement::Map(map) => {
-                assert_eq!(
-                    *map.get("key").unwrap(),
-                    ConfigElement::Str("value".to_string())
-                );
-            }
-            _ => panic!("Not a map"),
-        }
+    fn values(&self) -> Vec<&dyn ConfigElement> {
+        serde_json::Map::values(self)
+            .map(|t| t as &dyn ConfigElement)
+            .collect()
     }
 }

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -9,6 +9,13 @@ pub trait ConfigElementListType {
     // This function strangely has to be named something else than `get` because we cannot use
     // `Vec::get` in the impl for Vec<T> otherwise.
     fn at_index(&self, index: usize) -> Option<&dyn ConfigElement>;
+
+    /// Check whether the list object is empty
+    ///
+    /// Auto-implemented using Self::len().
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl<T> ConfigElementListType for Vec<T>

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -1,304 +1,253 @@
-use std::collections::HashMap;
-
 use crate::{
     accessor::{AccessType, Accessor},
     object::ConfigObjectAccessError,
 };
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize)]
-#[serde(untagged)]
-pub enum ConfigElement {
-    Null,
-    Bool(bool),
-    I8(i8),
-    I16(i16),
-    I32(i32),
-    I64(i64),
-    U8(u8),
-    U16(u16),
-    U32(u32),
-    U64(u64),
-    F32(f32),
-    F64(f64),
-    Str(String),
-    List(Vec<ConfigElement>),
-    Map(HashMap<String, ConfigElement>),
+pub trait ConfigElementListType {
+    fn len(&self) -> usize;
+
+    // This function strangely has to be named something else than `get` because we cannot use
+    // `Vec::get` in the impl for Vec<T> otherwise.
+    fn at_index(&self, index: usize) -> Option<&dyn ConfigElement>;
 }
 
-impl ConfigElement {
-    pub(crate) fn get(
+impl<T> ConfigElementListType for Vec<T>
+where
+    T: ConfigElement,
+{
+    fn len(&self) -> usize {
+        Vec::len(self)
+    }
+
+    fn at_index(&self, index: usize) -> Option<&dyn ConfigElement> {
+        self.get(index).map(|t| t as &dyn ConfigElement)
+    }
+}
+
+pub trait ConfigElementMapType {
+    fn get(&self, key: &str) -> Option<&dyn ConfigElement>;
+
+    fn contains_key(&self, key: &str) -> bool {
+        self.get(key).is_some()
+    }
+
+    fn keys(&self) -> Vec<String>;
+    fn values(&self) -> Vec<&dyn ConfigElement>;
+}
+
+/// The ConfigElement trait that makes a type usable with this crate
+///
+/// # Warning
+///
+/// Each implementation of this trait MUST guarantee that one of the functions named `as_*` return
+/// `Some(_)`.
+/// In other words: If there can be an object constructed where all `as_*` functions return `None`,
+/// all guarantees of this library are void and panics might happen in this library.
+///
+/// # Implementing
+///
+/// A user of this library may only implement the `as_*` functions of this trait. The `is_*`
+/// functions are auto-implemented by calling the corrosponding `as_*` function and checking the
+/// returned `Option` with `Option::is_some()`. If it is the case that that behaviour is
+/// inefficient for a implementation of this trait, the user is welcome to implement the `is_*`
+/// functions themselves!
+///
+/// The `get_type()` function is auto-implemented using the `is_*` functions, to return a
+/// `ConfigElementType`, that is internally used in this library.
+///
+/// The `access()` function should not be overridden by the user. It is used by this library to
+/// traverse the object tree when accessing values in a configuration.
+pub trait ConfigElement: std::fmt::Debug + downcast_rs::DowncastSync {
+    fn as_bool(&self) -> Option<bool>;
+    fn as_i8(&self) -> Option<i8>;
+    fn as_i16(&self) -> Option<i16>;
+    fn as_i32(&self) -> Option<i32>;
+    fn as_i64(&self) -> Option<i64>;
+    fn as_u8(&self) -> Option<u8>;
+    fn as_u16(&self) -> Option<u16>;
+    fn as_u32(&self) -> Option<u32>;
+    fn as_u64(&self) -> Option<u64>;
+    fn as_f32(&self) -> Option<f32>;
+    fn as_f64(&self) -> Option<f64>;
+    fn as_str(&self) -> Option<&str>;
+    fn as_list(&self) -> Option<&dyn ConfigElementListType>;
+    fn as_map(&self) -> Option<&dyn ConfigElementMapType>;
+
+    fn is_null(&self) -> bool;
+    fn is_bool(&self) -> bool {
+        self.as_bool().is_some()
+    }
+    fn is_i8(&self) -> bool {
+        self.as_i8().is_some()
+    }
+    fn is_i16(&self) -> bool {
+        self.as_i16().is_some()
+    }
+    fn is_i32(&self) -> bool {
+        self.as_i32().is_some()
+    }
+    fn is_i64(&self) -> bool {
+        self.as_i64().is_some()
+    }
+    fn is_u8(&self) -> bool {
+        self.as_u8().is_some()
+    }
+    fn is_u16(&self) -> bool {
+        self.as_u16().is_some()
+    }
+    fn is_u32(&self) -> bool {
+        self.as_u32().is_some()
+    }
+    fn is_u64(&self) -> bool {
+        self.as_u64().is_some()
+    }
+    fn is_f32(&self) -> bool {
+        self.as_f32().is_some()
+    }
+    fn is_f64(&self) -> bool {
+        self.as_f64().is_some()
+    }
+    fn is_str(&self) -> bool {
+        self.as_str().is_some()
+    }
+    fn is_list(&self) -> bool {
+        self.as_list().is_some()
+    }
+    fn is_map(&self) -> bool {
+        self.as_map().is_some()
+    }
+
+    fn access(
         &self,
         accessor: &mut Accessor,
-    ) -> Result<Option<&ConfigElement>, ConfigObjectAccessError> {
-        match (accessor.current(), &self) {
-            (Some(AccessType::Key(k)), ConfigElement::Null) => {
+    ) -> Result<Option<&dyn ConfigElement>, ConfigObjectAccessError> {
+        match accessor.current() {
+            Some(AccessType::Key(k)) if self.is_null() => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnNull(k.to_string()))
             }
-            (Some(AccessType::Key(k)), ConfigElement::Bool(_)) => {
+            Some(AccessType::Key(k)) if self.is_bool() => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnBool(k.to_string()))
             }
-            (Some(AccessType::Key(k)), ConfigElement::I8(_)) => {
+            Some(AccessType::Key(k)) if self.is_i8() => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnI8(k.to_string()))
             }
-            (Some(AccessType::Key(k)), ConfigElement::I16(_)) => {
+            Some(AccessType::Key(k)) if self.is_i16() => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnI16(k.to_string()))
             }
-            (Some(AccessType::Key(k)), ConfigElement::I32(_)) => {
+            Some(AccessType::Key(k)) if self.is_i32() => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnI32(k.to_string()))
             }
-            (Some(AccessType::Key(k)), ConfigElement::I64(_)) => {
+            Some(AccessType::Key(k)) if self.is_i64() => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnI64(k.to_string()))
             }
-            (Some(AccessType::Key(k)), ConfigElement::U8(_)) => {
+            Some(AccessType::Key(k)) if self.is_u8() => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnU8(k.to_string()))
             }
-            (Some(AccessType::Key(k)), ConfigElement::U16(_)) => {
+            Some(AccessType::Key(k)) if self.is_u16() => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnU16(k.to_string()))
             }
-            (Some(AccessType::Key(k)), ConfigElement::U32(_)) => {
+            Some(AccessType::Key(k)) if self.is_u32() => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnU32(k.to_string()))
             }
-            (Some(AccessType::Key(k)), ConfigElement::U64(_)) => {
+            Some(AccessType::Key(k)) if self.is_u64() => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnU64(k.to_string()))
             }
-            (Some(AccessType::Key(k)), ConfigElement::F32(_)) => {
+            Some(AccessType::Key(k)) if self.is_f32() => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnF32(k.to_string()))
             }
-            (Some(AccessType::Key(k)), ConfigElement::F64(_)) => {
+            Some(AccessType::Key(k)) if self.is_f64() => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnF64(k.to_string()))
             }
-            (Some(AccessType::Key(k)), ConfigElement::Str(_)) => {
+            Some(AccessType::Key(k)) if self.is_str() => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnStr(k.to_string()))
             }
-            (Some(AccessType::Key(k)), ConfigElement::List(_)) => {
+            Some(AccessType::Key(k)) if self.is_list() => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnList(k.to_string()))
             }
-            (Some(AccessType::Key(k)), ConfigElement::Map(hm)) => {
-                if let Some(value) = hm.get(k.as_str()) {
-                    accessor.advance();
-                    if accessor.current().is_none() {
-                        Ok(Some(value))
+            Some(AccessType::Key(k)) => {
+                if let Some(hm) = self.as_map() {
+                    if let Some(value) = hm.get(k.as_str()) {
+                        accessor.advance();
+                        if accessor.current().is_none() {
+                            Ok(Some(value))
+                        } else {
+                            value.access(accessor)
+                        }
                     } else {
-                        value.get(accessor)
+                        Ok(None)
                     }
                 } else {
-                    Ok(None)
+                    unreachable!()
                 }
             }
 
-            (Some(AccessType::Index(u)), ConfigElement::Null) => {
+            Some(AccessType::Index(u)) if self.is_null() => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnNull(*u))
             }
-            (Some(AccessType::Index(u)), ConfigElement::Bool(_)) => {
+            Some(AccessType::Index(u)) if self.is_bool() => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnBool(*u))
             }
-            (Some(AccessType::Index(u)), ConfigElement::I8(_)) => {
+            Some(AccessType::Index(u)) if self.is_i8() => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnI8(*u))
             }
-            (Some(AccessType::Index(u)), ConfigElement::I16(_)) => {
+            Some(AccessType::Index(u)) if self.is_i16() => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnI16(*u))
             }
-            (Some(AccessType::Index(u)), ConfigElement::I32(_)) => {
+            Some(AccessType::Index(u)) if self.is_i32() => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnI32(*u))
             }
-            (Some(AccessType::Index(u)), ConfigElement::I64(_)) => {
+            Some(AccessType::Index(u)) if self.is_i64() => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnI64(*u))
             }
-            (Some(AccessType::Index(u)), ConfigElement::U8(_)) => {
+            Some(AccessType::Index(u)) if self.is_u8() => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnU8(*u))
             }
-            (Some(AccessType::Index(u)), ConfigElement::U16(_)) => {
+            Some(AccessType::Index(u)) if self.is_u16() => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnU16(*u))
             }
-            (Some(AccessType::Index(u)), ConfigElement::U32(_)) => {
+            Some(AccessType::Index(u)) if self.is_u32() => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnU32(*u))
             }
-            (Some(AccessType::Index(u)), ConfigElement::U64(_)) => {
+            Some(AccessType::Index(u)) if self.is_u64() => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnU64(*u))
             }
-            (Some(AccessType::Index(u)), ConfigElement::F32(_)) => {
+            Some(AccessType::Index(u)) if self.is_f32() => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnF32(*u))
             }
-            (Some(AccessType::Index(u)), ConfigElement::F64(_)) => {
+            Some(AccessType::Index(u)) if self.is_f64() => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnF64(*u))
             }
-            (Some(AccessType::Index(u)), ConfigElement::Str(_)) => {
+            Some(AccessType::Index(u)) if self.is_str() => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnStr(*u))
             }
-            (Some(AccessType::Index(u)), ConfigElement::List(v)) => {
-                if let Some(value) = v.get(*u) {
-                    accessor.advance();
-                    if accessor.current().is_none() {
-                        Ok(Some(value))
-                    } else {
-                        value.get(accessor)
-                    }
-                } else {
-                    Ok(None)
-                }
-            }
-            (Some(AccessType::Index(u)), ConfigElement::Map(_)) => {
+            Some(AccessType::Index(u)) if self.is_map() => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnMap(*u))
             }
+            Some(AccessType::Index(u)) => {
+                if let Some(list) = self.as_list() {
+                    if let Some(value) = list.at_index(*u) {
+                        accessor.advance();
+                        if accessor.current().is_none() {
+                            Ok(Some(value))
+                        } else {
+                            value.access(accessor)
+                        }
+                    } else {
+                        Ok(None)
+                    }
+                } else {
+                    unreachable!()
+                }
+            }
 
-            (None, _) => Err(ConfigObjectAccessError::NoAccessor),
-        }
-    }
-
-    pub fn is_null(&self) -> bool {
-        std::matches!(self, ConfigElement::Null)
-    }
-
-    pub fn is_bool(&self) -> bool {
-        std::matches!(self, ConfigElement::Bool(_))
-    }
-
-    pub fn is_i8(&self) -> bool {
-        std::matches!(self, ConfigElement::I8(_))
-    }
-
-    pub fn is_i16(&self) -> bool {
-        std::matches!(self, ConfigElement::I16(_))
-    }
-
-    pub fn is_i32(&self) -> bool {
-        std::matches!(self, ConfigElement::I32(_))
-    }
-
-    pub fn is_i64(&self) -> bool {
-        std::matches!(self, ConfigElement::I64(_))
-    }
-
-    pub fn is_u8(&self) -> bool {
-        std::matches!(self, ConfigElement::U8(_))
-    }
-
-    pub fn is_u16(&self) -> bool {
-        std::matches!(self, ConfigElement::U16(_))
-    }
-
-    pub fn is_u32(&self) -> bool {
-        std::matches!(self, ConfigElement::U32(_))
-    }
-
-    pub fn is_u64(&self) -> bool {
-        std::matches!(self, ConfigElement::U64(_))
-    }
-
-    pub fn is_str(&self) -> bool {
-        std::matches!(self, ConfigElement::Str(_))
-    }
-
-    pub fn is_list(&self) -> bool {
-        std::matches!(self, ConfigElement::List(_))
-    }
-
-    pub fn is_map(&self) -> bool {
-        std::matches!(self, ConfigElement::Map(_))
-    }
-
-    pub fn as_bool(&self) -> Option<bool> {
-        if let ConfigElement::Bool(o) = self {
-            Some(*o)
-        } else {
-            None
-        }
-    }
-
-    pub fn as_i8(&self) -> Option<i8> {
-        if let ConfigElement::I8(o) = self {
-            Some(*o)
-        } else {
-            None
-        }
-    }
-
-    pub fn as_i16(&self) -> Option<i16> {
-        if let ConfigElement::I16(o) = self {
-            Some(*o)
-        } else {
-            None
-        }
-    }
-
-    pub fn as_i32(&self) -> Option<i32> {
-        if let ConfigElement::I32(o) = self {
-            Some(*o)
-        } else {
-            None
-        }
-    }
-
-    pub fn as_i64(&self) -> Option<i64> {
-        if let ConfigElement::I64(o) = self {
-            Some(*o)
-        } else {
-            None
-        }
-    }
-
-    pub fn as_u8(&self) -> Option<u8> {
-        if let ConfigElement::U8(o) = self {
-            Some(*o)
-        } else {
-            None
-        }
-    }
-
-    pub fn as_u16(&self) -> Option<u16> {
-        if let ConfigElement::U16(o) = self {
-            Some(*o)
-        } else {
-            None
-        }
-    }
-
-    pub fn as_u32(&self) -> Option<u32> {
-        if let ConfigElement::U32(o) = self {
-            Some(*o)
-        } else {
-            None
-        }
-    }
-
-    pub fn as_u64(&self) -> Option<u64> {
-        if let ConfigElement::U64(o) = self {
-            Some(*o)
-        } else {
-            None
-        }
-    }
-
-    pub fn as_str(&self) -> Option<&str> {
-        if let ConfigElement::Str(ref o) = self {
-            Some(o)
-        } else {
-            None
-        }
-    }
-
-    pub fn as_list(&self) -> Option<&[ConfigElement]> {
-        if let ConfigElement::List(ref o) = self {
-            Some(o)
-        } else {
-            None
-        }
-    }
-
-    pub fn as_map(&self) -> Option<&HashMap<String, ConfigElement>> {
-        if let ConfigElement::Map(ref o) = self {
-            Some(o)
-        } else {
-            None
+            None => Err(ConfigObjectAccessError::NoAccessor),
         }
     }
 }
 
-pub trait IntoConfigElement {
-    type Error: std::error::Error;
+downcast_rs::impl_downcast!(sync ConfigElement);
 
-    fn into_config_element(self) -> Result<ConfigElement, Self::Error>;
-}
+static_assertions::assert_obj_safe!(ConfigElement);
 
 #[cfg(feature = "json")]
 pub mod json;
@@ -311,8 +260,6 @@ mod tests {
     #[test]
     #[cfg(feature = "toml")]
     fn test_nested_toml_config() {
-        use crate::element::ConfigElement;
-        use crate::element::IntoConfigElement;
         use crate::Config;
 
         let toml: toml::Value = toml::from_str(
@@ -325,7 +272,7 @@ mod tests {
         )
         .unwrap();
 
-        let source = crate::source::test_source::TestSource(toml.into_config_element().unwrap());
+        let source = crate::source::test_source::TestSource(toml);
 
         let c = Config::builder().load(Box::new(source)).build().unwrap();
 
@@ -334,27 +281,21 @@ mod tests {
         let r = r.unwrap();
         assert!(r.is_some());
         let r = r.unwrap();
-        match r {
-            ConfigElement::Str(s) => assert_eq!(s, "value2"),
-            _ => panic!(),
-        }
+        assert!(r.is_str());
+        assert_eq!(r.as_str().unwrap(), "value2");
 
         let r = c.get("table.key2");
         assert!(r.is_ok());
         let r = r.unwrap();
         assert!(r.is_some());
         let r = r.unwrap();
-        match r {
-            ConfigElement::Str(s) => assert_eq!(s, "value3"),
-            _ => panic!(),
-        }
+        assert!(r.is_str());
+        assert_eq!(r.as_str().unwrap(), "value3");
     }
 
     #[test]
     #[cfg(feature = "toml")]
     fn test_nested_toml_config_with_index() {
-        use crate::element::ConfigElement;
-        use crate::element::IntoConfigElement;
         use crate::Config;
 
         let toml: toml::Value = toml::from_str(
@@ -368,7 +309,7 @@ mod tests {
         )
         .unwrap();
 
-        let source = crate::source::test_source::TestSource(toml.into_config_element().unwrap());
+        let source = crate::source::test_source::TestSource(toml);
 
         let c = Config::builder().load(Box::new(source)).build().unwrap();
 
@@ -377,9 +318,7 @@ mod tests {
         let r = r.unwrap();
         assert!(r.is_some());
         let r = r.unwrap();
-        match r {
-            ConfigElement::Str(s) => assert_eq!(s, "a"),
-            _ => panic!(),
-        }
+        assert!(r.is_str());
+        assert_eq!(r.as_str().unwrap(), "a");
     }
 }

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -117,54 +117,107 @@ pub trait ConfigElement: std::fmt::Debug + downcast_rs::DowncastSync {
         self.as_map().is_some()
     }
 
+    /// Internal helper function
+    ///
+    /// Is automatically implemented using the ConfigElement::is_* functions
+    fn get_type(&self) -> ConfigElementType {
+        if self.is_null() {
+            return ConfigElementType::Null;
+        }
+        if self.is_bool() {
+            return ConfigElementType::Bool;
+        }
+        if self.is_i8() {
+            return ConfigElementType::I8;
+        }
+        if self.is_i16() {
+            return ConfigElementType::I16;
+        }
+        if self.is_i32() {
+            return ConfigElementType::I32;
+        }
+        if self.is_i64() {
+            return ConfigElementType::I64;
+        }
+        if self.is_u8() {
+            return ConfigElementType::U8;
+        }
+        if self.is_u16() {
+            return ConfigElementType::U16;
+        }
+        if self.is_u32() {
+            return ConfigElementType::U32;
+        }
+        if self.is_u64() {
+            return ConfigElementType::U64;
+        }
+        if self.is_f32() {
+            return ConfigElementType::F32;
+        }
+        if self.is_f64() {
+            return ConfigElementType::F64;
+        }
+        if self.is_str() {
+            return ConfigElementType::Str;
+        }
+        if self.is_list() {
+            return ConfigElementType::List;
+        }
+        if self.is_map() {
+            return ConfigElementType::Map;
+        }
+
+        unreachable!()
+    }
+
     fn access(
         &self,
         accessor: &mut Accessor,
     ) -> Result<Option<&dyn ConfigElement>, ConfigObjectAccessError> {
-        match accessor.current() {
-            Some(AccessType::Key(k)) if self.is_null() => {
+        match (accessor.current(), self.get_type()) {
+            (Some(AccessType::Key(k)), ConfigElementType::Null) => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnNull(k.to_string()))
             }
-            Some(AccessType::Key(k)) if self.is_bool() => {
+            (Some(AccessType::Key(k)), ConfigElementType::Bool) => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnBool(k.to_string()))
             }
-            Some(AccessType::Key(k)) if self.is_i8() => {
+            (Some(AccessType::Key(k)), ConfigElementType::I8) => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnI8(k.to_string()))
             }
-            Some(AccessType::Key(k)) if self.is_i16() => {
+            (Some(AccessType::Key(k)), ConfigElementType::I16) => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnI16(k.to_string()))
             }
-            Some(AccessType::Key(k)) if self.is_i32() => {
+            (Some(AccessType::Key(k)), ConfigElementType::I32) => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnI32(k.to_string()))
             }
-            Some(AccessType::Key(k)) if self.is_i64() => {
+            (Some(AccessType::Key(k)), ConfigElementType::I64) => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnI64(k.to_string()))
             }
-            Some(AccessType::Key(k)) if self.is_u8() => {
+            (Some(AccessType::Key(k)), ConfigElementType::U8) => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnU8(k.to_string()))
             }
-            Some(AccessType::Key(k)) if self.is_u16() => {
+            (Some(AccessType::Key(k)), ConfigElementType::U16) => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnU16(k.to_string()))
             }
-            Some(AccessType::Key(k)) if self.is_u32() => {
+            (Some(AccessType::Key(k)), ConfigElementType::U32) => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnU32(k.to_string()))
             }
-            Some(AccessType::Key(k)) if self.is_u64() => {
+            (Some(AccessType::Key(k)), ConfigElementType::U64) => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnU64(k.to_string()))
             }
-            Some(AccessType::Key(k)) if self.is_f32() => {
+            (Some(AccessType::Key(k)), ConfigElementType::F32) => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnF32(k.to_string()))
             }
-            Some(AccessType::Key(k)) if self.is_f64() => {
+            (Some(AccessType::Key(k)), ConfigElementType::F64) => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnF64(k.to_string()))
             }
-            Some(AccessType::Key(k)) if self.is_str() => {
+            (Some(AccessType::Key(k)), ConfigElementType::Str) => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnStr(k.to_string()))
             }
-            Some(AccessType::Key(k)) if self.is_list() => {
+            (Some(AccessType::Key(k)), ConfigElementType::List) => {
                 Err(ConfigObjectAccessError::AccessWithKeyOnList(k.to_string()))
             }
-            Some(AccessType::Key(k)) => {
+            (Some(AccessType::Key(k)), ConfigElementType::Map) => {
                 if let Some(hm) = self.as_map() {
                     if let Some(value) = hm.get(k.as_str()) {
                         accessor.advance();
@@ -181,49 +234,49 @@ pub trait ConfigElement: std::fmt::Debug + downcast_rs::DowncastSync {
                 }
             }
 
-            Some(AccessType::Index(u)) if self.is_null() => {
+            (Some(AccessType::Index(u)), ConfigElementType::Null) => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnNull(*u))
             }
-            Some(AccessType::Index(u)) if self.is_bool() => {
+            (Some(AccessType::Index(u)), ConfigElementType::Bool) => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnBool(*u))
             }
-            Some(AccessType::Index(u)) if self.is_i8() => {
+            (Some(AccessType::Index(u)), ConfigElementType::I8) => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnI8(*u))
             }
-            Some(AccessType::Index(u)) if self.is_i16() => {
+            (Some(AccessType::Index(u)), ConfigElementType::I16) => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnI16(*u))
             }
-            Some(AccessType::Index(u)) if self.is_i32() => {
+            (Some(AccessType::Index(u)), ConfigElementType::I32) => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnI32(*u))
             }
-            Some(AccessType::Index(u)) if self.is_i64() => {
+            (Some(AccessType::Index(u)), ConfigElementType::I64) => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnI64(*u))
             }
-            Some(AccessType::Index(u)) if self.is_u8() => {
+            (Some(AccessType::Index(u)), ConfigElementType::U8) => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnU8(*u))
             }
-            Some(AccessType::Index(u)) if self.is_u16() => {
+            (Some(AccessType::Index(u)), ConfigElementType::U16) => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnU16(*u))
             }
-            Some(AccessType::Index(u)) if self.is_u32() => {
+            (Some(AccessType::Index(u)), ConfigElementType::U32) => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnU32(*u))
             }
-            Some(AccessType::Index(u)) if self.is_u64() => {
+            (Some(AccessType::Index(u)), ConfigElementType::U64) => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnU64(*u))
             }
-            Some(AccessType::Index(u)) if self.is_f32() => {
+            (Some(AccessType::Index(u)), ConfigElementType::F32) => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnF32(*u))
             }
-            Some(AccessType::Index(u)) if self.is_f64() => {
+            (Some(AccessType::Index(u)), ConfigElementType::F64) => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnF64(*u))
             }
-            Some(AccessType::Index(u)) if self.is_str() => {
+            (Some(AccessType::Index(u)), ConfigElementType::Str) => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnStr(*u))
             }
-            Some(AccessType::Index(u)) if self.is_map() => {
+            (Some(AccessType::Index(u)), ConfigElementType::Map) => {
                 Err(ConfigObjectAccessError::AccessWithIndexOnMap(*u))
             }
-            Some(AccessType::Index(u)) => {
+            (Some(AccessType::Index(u)), ConfigElementType::List) => {
                 if let Some(list) = self.as_list() {
                     if let Some(value) = list.at_index(*u) {
                         accessor.advance();
@@ -240,9 +293,27 @@ pub trait ConfigElement: std::fmt::Debug + downcast_rs::DowncastSync {
                 }
             }
 
-            None => Err(ConfigObjectAccessError::NoAccessor),
+            (None, _) => Err(ConfigObjectAccessError::NoAccessor),
         }
     }
+}
+
+pub enum ConfigElementType {
+    Null,
+    Bool,
+    I8,
+    I16,
+    I32,
+    I64,
+    U8,
+    U16,
+    U32,
+    U64,
+    F32,
+    F64,
+    Str,
+    List,
+    Map,
 }
 
 downcast_rs::impl_downcast!(sync ConfigElement);

--- a/src/element/toml.rs
+++ b/src/element/toml.rs
@@ -1,54 +1,179 @@
-use std::collections::HashMap;
-
 use crate::element::ConfigElement;
-use crate::element::IntoConfigElement;
 
-#[derive(Debug, thiserror::Error)]
-pub enum TomlIntoConfigElementError {}
+use toml::Value;
 
-impl IntoConfigElement for toml::Value {
-    type Error = TomlIntoConfigElementError;
+use super::{ConfigElementListType, ConfigElementMapType};
 
-    fn into_config_element(self) -> Result<ConfigElement, Self::Error> {
-        match self {
-            toml::Value::String(s) => Ok(ConfigElement::Str(s)),
-            toml::Value::Integer(i) => Ok(ConfigElement::I64(i)),
-            toml::Value::Float(f) => Ok(ConfigElement::F64(f)),
-            toml::Value::Boolean(b) => Ok(ConfigElement::Bool(b)),
-            toml::Value::Datetime(_) => unimplemented!(), // TODO
-            toml::Value::Array(ary) => ary
-                .into_iter()
-                .map(|e| e.into_config_element())
-                .collect::<Result<Vec<_>, Self::Error>>()
-                .map(ConfigElement::List),
-            toml::Value::Table(table) => table
-                .into_iter()
-                .map(|(k, v)| v.into_config_element().map(|v| (k.to_string(), v)))
-                .collect::<Result<HashMap<String, ConfigElement>, Self::Error>>()
-                .map(ConfigElement::Map),
-        }
+impl ConfigElement for Value {
+    fn is_null(&self) -> bool {
+        false // TOML has no Null
+    }
+
+    fn is_bool(&self) -> bool {
+        std::matches!(self, Value::Boolean(_))
+    }
+
+    fn is_i8(&self) -> bool {
+        self.as_integer()
+            .filter(|i| *i < (i8::MAX as i64))
+            .is_some()
+    }
+
+    fn is_i16(&self) -> bool {
+        self.as_integer()
+            .filter(|i| *i < (i16::MAX as i64))
+            .is_some()
+    }
+
+    fn is_i32(&self) -> bool {
+        self.as_integer()
+            .filter(|i| *i < (i32::MAX as i64))
+            .is_some()
+    }
+
+    fn is_i64(&self) -> bool {
+        self.is_integer()
+    }
+
+    fn is_u8(&self) -> bool {
+        self.as_integer()
+            .filter(|i| i.is_positive())
+            .filter(|i| *i < (u8::MAX as i64))
+            .is_some()
+    }
+
+    fn is_u16(&self) -> bool {
+        self.as_integer()
+            .filter(|i| i.is_positive())
+            .filter(|i| *i < (u16::MAX as i64))
+            .is_some()
+    }
+
+    fn is_u32(&self) -> bool {
+        self.as_integer()
+            .filter(|i| i.is_positive())
+            .filter(|i| *i < (u32::MAX as i64))
+            .is_some()
+    }
+
+    fn is_u64(&self) -> bool {
+        self.as_integer()
+            .filter(|i| i.is_positive())
+            .filter(|i| *i < (u64::MAX as i64))
+            .is_some()
+    }
+
+    fn is_f32(&self) -> bool {
+        self.as_float()
+            .filter(|f| *f < (f32::MAX as f64) && *f > (f32::MIN as f64))
+            .is_some()
+    }
+
+    fn is_f64(&self) -> bool {
+        self.is_float()
+    }
+
+    fn is_str(&self) -> bool {
+        std::matches!(self, Value::String(_))
+    }
+
+    fn is_list(&self) -> bool {
+        std::matches!(self, Value::Array(_))
+    }
+
+    fn is_map(&self) -> bool {
+        std::matches!(self, Value::Table(_))
+    }
+
+    fn as_bool(&self) -> Option<bool> {
+        self.as_bool()
+    }
+
+    fn as_i8(&self) -> Option<i8> {
+        self.as_integer()
+            .filter(|i| (*i < (i8::MAX as i64)))
+            .map(|i| i as i8)
+    }
+
+    fn as_i16(&self) -> Option<i16> {
+        self.as_integer()
+            .filter(|i| (*i < (i16::MAX as i64)))
+            .map(|i| i as i16)
+    }
+
+    fn as_i32(&self) -> Option<i32> {
+        self.as_integer()
+            .filter(|i| (*i < (i32::MAX as i64)))
+            .map(|i| i as i32)
+    }
+
+    fn as_i64(&self) -> Option<i64> {
+        self.as_integer()
+    }
+
+    fn as_u8(&self) -> Option<u8> {
+        self.as_integer()
+            .filter(|i| i.is_positive())
+            .filter(|i| (*i < (u8::MAX as i64)))
+            .map(|i| i as u8)
+    }
+
+    fn as_u16(&self) -> Option<u16> {
+        self.as_integer()
+            .filter(|i| i.is_positive())
+            .filter(|i| (*i < (u16::MAX as i64)))
+            .map(|i| i as u16)
+    }
+
+    fn as_u32(&self) -> Option<u32> {
+        self.as_integer()
+            .filter(|i| i.is_positive())
+            .filter(|i| (*i < (u32::MAX as i64)))
+            .map(|i| i as u32)
+    }
+
+    fn as_u64(&self) -> Option<u64> {
+        self.as_integer()
+            .filter(|i| i.is_positive())
+            .filter(|i| (*i < (u64::MAX as i64)))
+            .map(|i| i as u64)
+    }
+
+    fn as_f32(&self) -> Option<f32> {
+        self.as_float()
+            .filter(|f| *f < (f32::MAX as f64) && *f > (f32::MIN as f64))
+            .map(|f| f as f32)
+    }
+
+    fn as_f64(&self) -> Option<f64> {
+        self.as_float()
+    }
+
+    fn as_str(&self) -> Option<&str> {
+        self.as_str()
+    }
+
+    fn as_list(&self) -> Option<&dyn ConfigElementListType> {
+        self.as_array().map(|a| a as &dyn ConfigElementListType)
+    }
+
+    fn as_map(&self) -> Option<&dyn ConfigElementMapType> {
+        self.as_table().map(|t| t as &dyn ConfigElementMapType)
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::element::ConfigElement;
+impl ConfigElementMapType for toml::map::Map<String, toml::Value> {
+    fn get(&self, key: &str) -> Option<&dyn ConfigElement> {
+        toml::map::Map::get(self, key).map(|t| t as &dyn ConfigElement)
+    }
 
-    #[test]
-    fn deser_toml_1() {
-        let s = r#"
-            key = "value"
-        "#;
+    fn keys(&self) -> Vec<String> {
+        toml::map::Map::keys(self).map(String::to_owned).collect()
+    }
 
-        let e: ConfigElement = toml::from_str(s).unwrap();
-        match e {
-            ConfigElement::Map(map) => {
-                assert_eq!(
-                    *map.get("key").unwrap(),
-                    ConfigElement::Str("value".to_string())
-                );
-            }
-            _ => panic!("Not a map"),
-        }
+    fn values(&self) -> Vec<&dyn ConfigElement> {
+        toml::map::Map::values(self)
+            .map(|t| t as &dyn ConfigElement)
+            .collect()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ pub use crate::config::Config;
 pub use crate::config::ConfigBuilder;
 pub use crate::description::ConfigSourceDescription;
 pub use crate::element::ConfigElement;
+pub use crate::element::ConfigElementListType;
+pub use crate::element::ConfigElementMapType;
 pub use crate::object::ConfigObject;
 pub use crate::source::ConfigSource;
 pub use crate::source::FileSource;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub use crate::object::ConfigObject;
 pub use crate::source::ConfigSource;
 pub use crate::source::FileSource;
 pub use crate::source::FormatParser;
+pub use crate::source::SourceError;
 pub use crate::source::StringSource;
 
 #[cfg(feature = "json")]

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -2,23 +2,30 @@ use crate::accessor::Accessor;
 use crate::description::ConfigSourceDescription;
 use crate::element::ConfigElement;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ConfigObject {
-    element: ConfigElement,
+    element: Box<dyn ConfigElement>,
     #[allow(unused)] // TODO
     source: ConfigSourceDescription,
 }
 
 impl ConfigObject {
-    pub(crate) fn new(element: ConfigElement, source: ConfigSourceDescription) -> Self {
+    pub(crate) fn new(element: Box<dyn ConfigElement>, source: ConfigSourceDescription) -> Self {
         Self { element, source }
     }
 
     pub(crate) fn get(
         &self,
         accessor: &mut Accessor,
-    ) -> Result<Option<&ConfigElement>, ConfigObjectAccessError> {
-        self.element.get(accessor)
+    ) -> Result<Option<&dyn ConfigElement>, ConfigObjectAccessError> {
+        self.element.access(accessor)
+    }
+
+    pub(crate) fn get_as<T: ConfigElement>(
+        &self,
+        accessor: &mut Accessor,
+    ) -> Result<Option<&T>, ConfigObjectAccessError> {
+        Ok(self.get(accessor)?.and_then(|t| t.downcast_ref()))
     }
 }
 

--- a/src/source/format.rs
+++ b/src/source/format.rs
@@ -1,11 +1,10 @@
-use crate::element::IntoConfigElement;
-
 use super::SourceError;
+use crate::element::ConfigElement;
 
 pub trait FormatParser: std::fmt::Debug {
-    type Output: IntoConfigElement + std::fmt::Debug + Sized;
+    type Output: ConfigElement + std::fmt::Debug + Sized;
 
-    fn parse(buffer: &[u8]) -> Result<Self::Output, SourceError>;
+    fn parse(buffer: Vec<u8>) -> Result<Self::Output, SourceError>;
 }
 
 #[cfg(feature = "json")]
@@ -16,8 +15,8 @@ pub struct JsonFormatParser;
 impl FormatParser for JsonFormatParser {
     type Output = serde_json::Value;
 
-    fn parse(buffer: &[u8]) -> Result<Self::Output, SourceError> {
-        serde_json::from_slice(buffer).map_err(SourceError::JsonParserError)
+    fn parse(buffer: Vec<u8>) -> Result<Self::Output, SourceError> {
+        serde_json::from_slice(&buffer).map_err(SourceError::JsonParserError)
     }
 }
 
@@ -29,7 +28,7 @@ pub struct TomlFormatParser;
 impl FormatParser for TomlFormatParser {
     type Output = toml::Value;
 
-    fn parse(buffer: &[u8]) -> Result<Self::Output, SourceError> {
-        toml::from_slice(buffer).map_err(SourceError::TomlParserError)
+    fn parse(buffer: Vec<u8>) -> Result<Self::Output, SourceError> {
+        toml::from_slice(&buffer).map_err(SourceError::TomlParserError)
     }
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -26,17 +26,9 @@ pub enum SourceError {
     #[error("JSON Parser error")]
     JsonParserError(#[from] serde_json::Error),
 
-    #[cfg(feature = "json")]
-    #[error("JSON load error")]
-    JsonLoadError(#[from] crate::element::json::JsonIntoConfigElementError),
-
     #[cfg(feature = "toml")]
     #[error("TOML Parser error")]
     TomlParserError(#[from] toml::de::Error),
-
-    #[cfg(feature = "toml")]
-    #[error("TOML load error")]
-    TomlLoadError(#[from] crate::element::toml::TomlIntoConfigElementError),
 }
 
 #[cfg(test)]
@@ -49,12 +41,15 @@ pub(crate) mod test_source {
     use super::SourceError;
 
     #[derive(Debug)]
-    pub(crate) struct TestSource(pub(crate) ConfigElement);
+    pub(crate) struct TestSource<T: ConfigElement + Clone>(pub(crate) T);
 
-    impl ConfigSource for TestSource {
+    impl<T> ConfigSource for TestSource<T>
+    where
+        T: ConfigElement + Clone,
+    {
         fn load(&self) -> Result<ConfigObject, SourceError> {
             Ok(ConfigObject::new(
-                self.0.clone(),
+                Box::new(self.0.clone()),
                 ConfigSourceDescription::Unknown,
             ))
         }

--- a/src/source/string.rs
+++ b/src/source/string.rs
@@ -1,5 +1,4 @@
 use crate::description::ConfigSourceDescription;
-use crate::element::IntoConfigElement;
 use crate::object::ConfigObject;
 use crate::source::format::FormatParser;
 use crate::ConfigSource;
@@ -24,14 +23,13 @@ impl<P: FormatParser> StringSource<P> {
 impl<P> ConfigSource for StringSource<P>
 where
     P: FormatParser + std::fmt::Debug,
-    SourceError: From<<<P as FormatParser>::Output as IntoConfigElement>::Error>,
+    <P as FormatParser>::Output: 'static,
 {
     fn load(&self) -> Result<ConfigObject, SourceError> {
-        let element = P::parse(self.source.as_bytes())?;
-        let element = element.into_config_element()?;
+        let element = P::parse(self.source.as_bytes().to_vec())?;
 
         let desc = ConfigSourceDescription::Custom("String".to_string());
-        Ok(ConfigObject::new(element, desc))
+        Ok(ConfigObject::new(Box::new(element), desc))
     }
 }
 
@@ -40,14 +38,13 @@ where
 impl<P> crate::source::AsyncConfigSource for StringSource<P>
 where
     P: FormatParser + std::marker::Sync + std::fmt::Debug,
-    SourceError: From<<<P as FormatParser>::Output as IntoConfigElement>::Error>,
+    <P as FormatParser>::Output: 'static,
 {
     async fn load_async(&self) -> Result<ConfigObject, SourceError> {
-        let element = P::parse(self.source.as_bytes())?;
-        let element = element.into_config_element()?;
+        let element = P::parse(self.source.as_bytes().to_vec())?;
 
         let desc = ConfigSourceDescription::Custom("String".to_string());
-        Ok(ConfigObject::new(element, desc))
+        Ok(ConfigObject::new(Box::new(element), desc))
     }
 }
 

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1,0 +1,213 @@
+use config_rs_ng::Config;
+use config_rs_ng::ConfigElement;
+use config_rs_ng::ConfigElementListType;
+use config_rs_ng::ConfigElementMapType;
+use config_rs_ng::JsonFormatParser;
+use config_rs_ng::StringSource;
+
+// JSON configuration
+const CONFIGURATION_LAYER_A: &str = r#"
+{
+    "key1": "valueA",
+    "key2": "valueA"
+}
+"#;
+
+// custom configuration format
+const CONFIGURATION_LAYER_B: &str = r#"
+mycustomformatkey(2) = valueB
+mycustomformatkey(3) = valueB
+"#;
+
+// A value in our custom config format
+#[derive(Debug)]
+pub enum CustomValue {
+    Str(String),
+    Map(Map),
+    // possibly more
+}
+
+// A map of values in our custom config format
+#[derive(Debug)]
+pub struct Map(std::collections::HashMap<String, CustomValue>);
+
+impl ConfigElementMapType for Map {
+    fn get(&self, key: &str) -> Option<&dyn ConfigElement> {
+        self.0.get(key).map(|v| v as &dyn ConfigElement)
+    }
+
+    fn keys(&self) -> Vec<String> {
+        self.0.keys().map(String::clone).collect()
+    }
+
+    fn values(&self) -> Vec<&dyn ConfigElement> {
+        self.0.values().map(|v| v as &dyn ConfigElement).collect()
+    }
+}
+
+// We need to implement ConfigElement for our custom config value type
+impl config_rs_ng::ConfigElement for CustomValue {
+    fn as_bool(&self) -> Option<bool> {
+        None
+    }
+
+    fn as_i8(&self) -> Option<i8> {
+        None
+    }
+
+    fn as_i16(&self) -> Option<i16> {
+        None
+    }
+
+    fn as_i32(&self) -> Option<i32> {
+        None
+    }
+
+    fn as_i64(&self) -> Option<i64> {
+        None
+    }
+
+    fn as_u8(&self) -> Option<u8> {
+        None
+    }
+
+    fn as_u16(&self) -> Option<u16> {
+        None
+    }
+
+    fn as_u32(&self) -> Option<u32> {
+        None
+    }
+
+    fn as_u64(&self) -> Option<u64> {
+        None
+    }
+
+    fn as_f32(&self) -> Option<f32> {
+        None
+    }
+
+    fn as_f64(&self) -> Option<f64> {
+        None
+    }
+
+    fn as_str(&self) -> Option<&str> {
+        if let CustomValue::Str(ref s) = self {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
+    fn as_list(&self) -> Option<&dyn ConfigElementListType> {
+        None
+    }
+
+    fn as_map(&self) -> Option<&dyn ConfigElementMapType> {
+        if let CustomValue::Map(map) = self {
+            Some(map as &dyn ConfigElementMapType)
+        } else {
+            None
+        }
+    }
+
+    fn is_str(&self) -> bool {
+        std::matches!(self, CustomValue::Str(_))
+    }
+
+    fn is_null(&self) -> bool {
+        false
+    }
+}
+
+// Helper type, not relevant for this test
+#[derive(Debug, thiserror::Error)]
+pub enum CustomError {}
+
+impl From<CustomError> for config_rs_ng::SourceError {
+    fn from(_: CustomError) -> config_rs_ng::SourceError {
+        unimplemented!()
+    }
+}
+
+// A parser for our custom config format
+#[derive(Debug)]
+struct CustomFormatParser;
+
+impl config_rs_ng::FormatParser for CustomFormatParser {
+    type Output = CustomValue;
+
+    // This parser implementation is just a quick-and-dirty one, that works only for the exact
+    // example config we wrote down above
+    fn parse(buffer: Vec<u8>) -> Result<Self::Output, config_rs_ng::SourceError> {
+        let s = String::from_utf8(buffer.to_vec()).unwrap();
+        let hm = s
+            .lines()
+            .skip_while(|l| l.is_empty())
+            .map(|line| {
+                let num = line
+                    .split('(')
+                    .nth(1)
+                    .expect("Splitting at '('")
+                    .split(')')
+                    .next()
+                    .expect("Element after '('");
+                let key = format!("key{}", num);
+                let val = line.split(" = ").nth(1).unwrap().to_string();
+                (key, CustomValue::Str(val))
+            })
+            .collect();
+        Ok(CustomValue::Map(Map(hm)))
+    }
+}
+
+#[test]
+fn test_format_custom() {
+    // Lets build a configuration object
+    let config = Config::builder()
+        // Lets load CONFIGURATION_LAYER_A from string using a JSON format parser that was shipped
+        // with config-rs
+        .load(Box::new({
+            StringSource::<JsonFormatParser>::new(CONFIGURATION_LAYER_A.to_string())
+                .expect("building StringSource")
+        }))
+        // Lets load CONFIGURATION_LAYER_B from string using our custom format parser that we have
+        // implemented above
+        .load(Box::new({
+            StringSource::<CustomFormatParser>::new(CONFIGURATION_LAYER_B.to_string())
+                .expect("building StringSource")
+        }))
+        .build()
+        .expect("Building configuration object");
+
+    // Now lets access our configuration object
+
+    {
+        // Lets get a serde_json::Value object by accessing "key1" from above
+        if let Some(json_object) = config
+            .get_as::<_, serde_json::Value>("key1")
+            .expect("Accessing configuration object")
+        {
+            let json_object: &serde_json::Value = json_object; // enforce type
+            assert!(json_object.is_string());
+            assert_eq!(json_object.as_str().unwrap(), "valueA");
+        } else {
+            panic!("Expected 'key1' to hold a JSON object");
+        }
+    }
+    {
+        // Lets get a CustomValue object by accessing "key2" from above
+        //
+        // This value has shadowed the "key2" from the JSON part of our config object!
+        if let Some(custom_object) = config
+            .get_as::<_, CustomValue>("key2")
+            .expect("Accessing configuration object")
+        {
+            let custom_object: &CustomValue = custom_object; // enforce type
+            assert!(custom_object.is_str());
+            assert_eq!(custom_object.as_str().unwrap(), "valueB");
+        } else {
+            panic!("Expected 'key2' to hold a CUSTOM object");
+        }
+    }
+}


### PR DESCRIPTION
This is a first sketch how the format-independence could look like on the users side of things.

The API is still verbose and a bit clumsy to work with, but FWIW, this is how it should basically look.
The important bit is the `get_as<T>(key)` function, that should be able to return the requested key as the actual format type, so `Some(serde_json::Value)` if the key is accessed on a json layer via `get_as::<serde_json::Value>("key1")` (as in the example) and `None` if it is some other type, or `Some(CustomValue)` if the key is accessed via `get_as::<CustomValue>("key2")` and so on...

This is only the first bit, of course. I'm not sure whether this suffices for span information yet?

---

FWIW, this won't run through CI because the library functions are not yet implemented.