### PR TITLE
Remove blockfixupmerge action

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -4,13 +4,6 @@ on:
 name: Pull Request Checks
 
 jobs:
-  block-fixup:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Block fixup commit merge
-      uses: 13rac1/block-fixup-merge-action@v2.0.0
-
   commit-lint:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'

--- a/.gitlint
+++ b/.gitlint
@@ -38,7 +38,7 @@ ignore-merge-commits=true
 
 # Enable community contributed rules
 # See http://jorisroovers.github.io/gitlint/contrib_rules for details
-contrib=CC1
+contrib=CC1, CC2
 
 # Set the extra-path where gitlint will search for user defined rules
 # See http://jorisroovers.github.io/gitlint/user_defined_rules for details
@@ -134,4 +134,5 @@ regex=(.*)dependabot(.*)
 # types = bugfix,user-story,epic
 [contrib-body-requires-signed-off-by]
 
+[contrib-disallow-cleanup-commits]
 


### PR DESCRIPTION
gitlint can do this now, so we don't need the block-fixup-merge-action anymore.