### PR TITLE
Add getter that can return source description

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub use crate::element::ConfigElement;
 pub use crate::element::ConfigElementListType;
 pub use crate::element::ConfigElementMapType;
 pub use crate::object::ConfigObject;
+pub use crate::object::ConfigView;
 pub use crate::source::ConfigSource;
 pub use crate::source::FileSource;
 pub use crate::source::FormatParser;

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -27,6 +27,22 @@ impl ConfigObject {
     ) -> Result<Option<&T>, ConfigObjectAccessError> {
         Ok(self.get(accessor)?.and_then(|t| t.downcast_ref()))
     }
+
+    pub(crate) fn get_with_description<'a>(
+        &'a self,
+        accessor: &mut Accessor,
+    ) -> Result<Option<ConfigView<'a>>, ConfigObjectAccessError> {
+        if let Some(element) = self.get(accessor)?.map(Box::new) {
+            Ok(Some({
+                ConfigView {
+                    element,
+                    desc: &self.source,
+                }
+            }))
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -91,4 +107,22 @@ pub enum ConfigObjectAccessError {
     AccessWithIndexOnStr(usize),
     #[error("Accessed Map with index '{0}'")]
     AccessWithIndexOnMap(usize),
+}
+
+/// An object that can be used to get a configuration value or the description of the source of
+/// that value.
+#[derive(Debug)]
+pub struct ConfigView<'a> {
+    element: Box<&'a dyn ConfigElement>,
+    desc: &'a ConfigSourceDescription,
+}
+
+impl<'a> ConfigView<'a> {
+    pub fn value(&self) -> &dyn ConfigElement {
+        &**self.element
+    }
+
+    pub fn description(&self) -> &ConfigSourceDescription {
+        self.desc
+    }
 }

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -32,7 +32,7 @@ impl ConfigObject {
         &'a self,
         accessor: &mut Accessor,
     ) -> Result<Option<ConfigView<'a>>, ConfigObjectAccessError> {
-        if let Some(element) = self.get(accessor)?.map(Box::new) {
+        if let Some(element) = self.get(accessor)? {
             Ok(Some({
                 ConfigView {
                     element,
@@ -113,13 +113,13 @@ pub enum ConfigObjectAccessError {
 /// that value.
 #[derive(Debug)]
 pub struct ConfigView<'a> {
-    element: Box<&'a dyn ConfigElement>,
+    element: &'a dyn ConfigElement,
     desc: &'a ConfigSourceDescription,
 }
 
 impl<'a> ConfigView<'a> {
     pub fn value(&self) -> &dyn ConfigElement {
-        &**self.element
+        self.element
     }
 
     pub fn description(&self) -> &ConfigSourceDescription {


### PR DESCRIPTION
This adds functionality to get the description of the source of a configuration value.