### PR TITLE
Not either syncasync

### DIFF
--- a/examples/async_file.rs
+++ b/examples/async_file.rs
@@ -3,7 +3,7 @@ async fn run_example() {}
 
 #[cfg(feature = "async")]
 async fn run_example() {
-    use config_rs_ng::Config;
+    use config_rs_ng::AsyncConfig;
     use config_rs_ng::FileSource;
     use config_rs_ng::JsonFormatParser;
 
@@ -14,7 +14,7 @@ async fn run_example() {
 
     println!("Loading file: {}", config_file.display());
 
-    let config = Config::builder()
+    let config = AsyncConfig::builder()
         .load(Box::new({
             FileSource::<JsonFormatParser>::new(config_file).expect("building FileSource")
         }))

--- a/examples/async_file.rs
+++ b/examples/async_file.rs
@@ -23,6 +23,7 @@ async fn run_example() {
         .expect("Building configuration object");
 
     let key = config
+        .layers()
         .get("foo")
         .expect("Accessing configuration object")
         .expect("Finding 'key' in configuration object");

--- a/src/config/async_builder.rs
+++ b/src/config/async_builder.rs
@@ -2,7 +2,7 @@ use futures::stream::FuturesUnordered;
 
 use crate::{
     source::{AsyncConfigSource, SourceError},
-    Config, ConfigObject,
+    AsyncConfig, ConfigObject,
 };
 
 use super::ConfigError;
@@ -39,8 +39,8 @@ impl AsyncConfigBuilder {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    pub async fn build(self) -> Result<Config, ConfigError> {
-        Config::build_from_builder(self).await
+    pub async fn build(self) -> Result<AsyncConfig, ConfigError> {
+        AsyncConfig::build_from_builder(self).await
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument)]

--- a/src/config/async_builder.rs
+++ b/src/config/async_builder.rs
@@ -2,10 +2,11 @@ use futures::stream::FuturesUnordered;
 
 use crate::{
     source::{AsyncConfigSource, SourceError},
-    AsyncConfig, ConfigObject,
+    AsyncConfig,
 };
 
 use super::ConfigError;
+use crate::config::layers::Layers;
 
 #[derive(Debug)]
 pub struct AsyncConfigBuilder {
@@ -44,7 +45,7 @@ impl AsyncConfigBuilder {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    pub(crate) async fn reload(&self) -> Result<Vec<ConfigObject>, SourceError> {
+    pub(crate) async fn reload(&self) -> Result<Layers, SourceError> {
         use futures::StreamExt;
 
         let overrides = self
@@ -90,6 +91,6 @@ impl AsyncConfigBuilder {
             .into_iter()
             .chain(layers.into_iter())
             .chain(defaults.into_iter())
-            .collect()
+            .collect::<Result<Layers, _>>()
     }
 }

--- a/src/config/async_config.rs
+++ b/src/config/async_config.rs
@@ -1,28 +1,28 @@
 use crate::accessor::Accessor;
 use crate::accessor::ParsableAccessor;
-
-use crate::config::ConfigBuilder;
-
+use crate::config::AsyncConfigBuilder;
 use crate::config::ConfigError;
 use crate::element::ConfigElement;
 use crate::object::ConfigObject;
 use crate::object::ConfigView;
 
 #[derive(Debug)]
-pub struct Config {
-    builder: ConfigBuilder,
+pub struct AsyncConfig {
+    builder: AsyncConfigBuilder,
     layers: Vec<ConfigObject>,
 }
 
-impl Config {
-    pub fn builder() -> ConfigBuilder {
-        ConfigBuilder::new()
+impl AsyncConfig {
+    pub fn builder() -> AsyncConfigBuilder {
+        AsyncConfigBuilder::new()
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    pub(super) fn build_from_builder(builder: ConfigBuilder) -> Result<Self, ConfigError> {
-        Ok(Config {
-            layers: builder.reload()?,
+    pub(super) async fn build_from_builder(
+        builder: crate::config::AsyncConfigBuilder,
+    ) -> Result<Self, ConfigError> {
+        Ok(Self {
+            layers: builder.reload().await?,
             builder,
         })
     }
@@ -128,8 +128,8 @@ impl Config {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    pub fn reload(&mut self) -> Result<(), ConfigError> {
-        let layers = self.builder.reload()?;
+    pub async fn reload(&mut self) -> Result<(), ConfigError> {
+        let layers = self.builder.reload().await?;
         self.layers = layers;
         Ok(())
     }

--- a/src/config/async_config.rs
+++ b/src/config/async_config.rs
@@ -1,15 +1,11 @@
-use crate::accessor::Accessor;
-use crate::accessor::ParsableAccessor;
 use crate::config::AsyncConfigBuilder;
 use crate::config::ConfigError;
-use crate::element::ConfigElement;
-use crate::object::ConfigObject;
-use crate::object::ConfigView;
+use crate::config::Layers;
 
 #[derive(Debug)]
 pub struct AsyncConfig {
     builder: AsyncConfigBuilder,
-    layers: Vec<ConfigObject>,
+    layers: crate::config::layers::Layers,
 }
 
 impl AsyncConfig {
@@ -21,116 +17,19 @@ impl AsyncConfig {
     pub(super) async fn build_from_builder(
         builder: crate::config::AsyncConfigBuilder,
     ) -> Result<Self, ConfigError> {
-        Ok(Self {
-            layers: builder.reload().await?,
-            builder,
-        })
-    }
-
-    /// Access the configuration at a specific position
-    ///
-    /// Use an object of a type implementing the `ParsableAccessor` trait for accessing the
-    /// configuration at a certain position.
-    /// As `ParsableAccessor` is implemented by [`&str`] and [`String`], passing those directly
-    /// works.
-    ///
-    /// # Note
-    ///
-    /// Each time, [`Config::get`] is called, the `ParsableAccessor::parse()` function is called.
-    /// If that is a unbearable overhead (especially in cases where the accessor is hard-coded),
-    /// [`Config::get_with_accessor`] can be used to prevent that overhead.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use config_rs_ng::Config;
-    /// let config: Config = { //...
-    /// # unimplemented!()
-    /// };
-    ///
-    /// config.get("foo")
-    ///     // ...
-    /// # ;
-    /// ```
-    pub fn get<A>(&self, accessor: A) -> Result<Option<&dyn ConfigElement>, ConfigError>
-    where
-        A: ParsableAccessor,
-    {
-        let accessor = accessor.parse()?;
-        self.get_with_accessor(accessor)
-    }
-
-    /// Get a "View" from the configuration
-    ///
-    /// The function works like [`Config::get`], except that it wraps the `&dyn ConfigElement` in a
-    /// `ConfigView` that also contains the description of the source of the configuration value.
-    pub fn get_view<A>(&self, accessor: A) -> Result<Option<ConfigView<'_>>, ConfigError>
-    where
-        A: ParsableAccessor,
-    {
-        let accessor = accessor.parse()?;
-        self.get_view_with_accessor(accessor)
-    }
-
-    /// Access the configuration at a specific position
-    ///
-    /// See [`Config::get`]
-    pub fn get_with_accessor(
-        &self,
-        mut accessor: Accessor,
-    ) -> Result<Option<&dyn ConfigElement>, ConfigError> {
-        for layer in self.layers.iter().rev() {
-            if let Some(value) = layer.get(&mut accessor)? {
-                return Ok(Some(value));
-            }
-        }
-
-        Ok(None)
-    }
-
-    /// Access the configuration at a specific position, and return the description of the value as
-    /// well
-    ///
-    /// See [`Config::get_view`]
-    pub fn get_view_with_accessor(
-        &self,
-        mut accessor: Accessor,
-    ) -> Result<Option<ConfigView<'_>>, ConfigError> {
-        for layer in self.layers.iter().rev() {
-            if let Some(view) = layer.get_with_description(&mut accessor)? {
-                return Ok(Some(view));
-            }
-        }
-
-        Ok(None)
-    }
-
-    pub fn get_as<A, T>(&self, accessor: A) -> Result<Option<&T>, ConfigError>
-    where
-        A: ParsableAccessor,
-        T: ConfigElement,
-    {
-        let accessor = accessor.parse()?;
-        self.get_with_accessor_as::<T>(accessor)
-    }
-
-    pub fn get_with_accessor_as<T>(&self, mut accessor: Accessor) -> Result<Option<&T>, ConfigError>
-    where
-        T: ConfigElement,
-    {
-        for layer in self.layers.iter().rev() {
-            if let Some(value) = layer.get_as::<T>(&mut accessor)? {
-                return Ok(Some(value));
-            }
-        }
-
-        Ok(None)
+        let layers: crate::config::layers::Layers = builder.reload().await?;
+        Ok(Self { layers, builder })
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument)]
     pub async fn reload(&mut self) -> Result<(), ConfigError> {
-        let layers = self.builder.reload().await?;
+        let layers: crate::config::layers::Layers = self.builder.reload().await?;
         self.layers = layers;
         Ok(())
+    }
+
+    /// Get the configuration layers and via them access to the actual values.
+    pub fn layers(&self) -> &Layers {
+        &self.layers
     }
 }

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -1,9 +1,9 @@
 use crate::config::Config;
-use crate::object::ConfigObject;
 use crate::source::ConfigSource;
 use crate::source::SourceError;
 
 use super::ConfigError;
+use crate::config::layers::Layers;
 
 #[derive(Debug)]
 pub struct ConfigBuilder {
@@ -42,7 +42,7 @@ impl ConfigBuilder {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    pub(crate) fn reload(&self) -> Result<Vec<ConfigObject>, SourceError> {
+    pub(crate) fn reload(&self) -> Result<Layers, SourceError> {
         self.overwrites_builders
             .iter()
             .map(|cs| cs.load())

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -1,17 +1,11 @@
-use crate::accessor::Accessor;
-use crate::accessor::ParsableAccessor;
-
 use crate::config::ConfigBuilder;
-
 use crate::config::ConfigError;
-use crate::element::ConfigElement;
-use crate::object::ConfigObject;
-use crate::object::ConfigView;
+use crate::config::Layers;
 
 #[derive(Debug)]
 pub struct Config {
     builder: ConfigBuilder,
-    layers: Vec<ConfigObject>,
+    layers: crate::config::layers::Layers,
 }
 
 impl Config {
@@ -27,110 +21,15 @@ impl Config {
         })
     }
 
-    /// Access the configuration at a specific position
-    ///
-    /// Use an object of a type implementing the `ParsableAccessor` trait for accessing the
-    /// configuration at a certain position.
-    /// As `ParsableAccessor` is implemented by [`&str`] and [`String`], passing those directly
-    /// works.
-    ///
-    /// # Note
-    ///
-    /// Each time, [`Config::get`] is called, the `ParsableAccessor::parse()` function is called.
-    /// If that is a unbearable overhead (especially in cases where the accessor is hard-coded),
-    /// [`Config::get_with_accessor`] can be used to prevent that overhead.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use config_rs_ng::Config;
-    /// let config: Config = { //...
-    /// # unimplemented!()
-    /// };
-    ///
-    /// config.get("foo")
-    ///     // ...
-    /// # ;
-    /// ```
-    pub fn get<A>(&self, accessor: A) -> Result<Option<&dyn ConfigElement>, ConfigError>
-    where
-        A: ParsableAccessor,
-    {
-        let accessor = accessor.parse()?;
-        self.get_with_accessor(accessor)
-    }
-
-    /// Get a "View" from the configuration
-    ///
-    /// The function works like [`Config::get`], except that it wraps the `&dyn ConfigElement` in a
-    /// `ConfigView` that also contains the description of the source of the configuration value.
-    pub fn get_view<A>(&self, accessor: A) -> Result<Option<ConfigView<'_>>, ConfigError>
-    where
-        A: ParsableAccessor,
-    {
-        let accessor = accessor.parse()?;
-        self.get_view_with_accessor(accessor)
-    }
-
-    /// Access the configuration at a specific position
-    ///
-    /// See [`Config::get`]
-    pub fn get_with_accessor(
-        &self,
-        mut accessor: Accessor,
-    ) -> Result<Option<&dyn ConfigElement>, ConfigError> {
-        for layer in self.layers.iter().rev() {
-            if let Some(value) = layer.get(&mut accessor)? {
-                return Ok(Some(value));
-            }
-        }
-
-        Ok(None)
-    }
-
-    /// Access the configuration at a specific position, and return the description of the value as
-    /// well
-    ///
-    /// See [`Config::get_view`]
-    pub fn get_view_with_accessor(
-        &self,
-        mut accessor: Accessor,
-    ) -> Result<Option<ConfigView<'_>>, ConfigError> {
-        for layer in self.layers.iter().rev() {
-            if let Some(view) = layer.get_with_description(&mut accessor)? {
-                return Ok(Some(view));
-            }
-        }
-
-        Ok(None)
-    }
-
-    pub fn get_as<A, T>(&self, accessor: A) -> Result<Option<&T>, ConfigError>
-    where
-        A: ParsableAccessor,
-        T: ConfigElement,
-    {
-        let accessor = accessor.parse()?;
-        self.get_with_accessor_as::<T>(accessor)
-    }
-
-    pub fn get_with_accessor_as<T>(&self, mut accessor: Accessor) -> Result<Option<&T>, ConfigError>
-    where
-        T: ConfigElement,
-    {
-        for layer in self.layers.iter().rev() {
-            if let Some(value) = layer.get_as::<T>(&mut accessor)? {
-                return Ok(Some(value));
-            }
-        }
-
-        Ok(None)
-    }
-
     #[cfg_attr(feature = "tracing", tracing::instrument)]
     pub fn reload(&mut self) -> Result<(), ConfigError> {
         let layers = self.builder.reload()?;
         self.layers = layers;
         Ok(())
+    }
+
+    /// Get the configuration layers and via them access to the actual values.
+    pub fn layers(&self) -> &Layers {
+        &self.layers
     }
 }

--- a/src/config/layers.rs
+++ b/src/config/layers.rs
@@ -1,0 +1,117 @@
+use crate::accessor::Accessor;
+use crate::config::ConfigError;
+use crate::element::ConfigElement;
+use crate::object::ConfigObject;
+use crate::object::ConfigView;
+use crate::ParsableAccessor;
+
+#[derive(Debug)]
+pub struct Layers(Vec<ConfigObject>);
+
+impl FromIterator<ConfigObject> for Layers {
+    fn from_iter<T: IntoIterator<Item = ConfigObject>>(iter: T) -> Self {
+        Layers(Vec::from_iter(iter))
+    }
+}
+
+impl Layers {
+    /// Access the configuration at a specific position
+    ///
+    /// Use an object of a type implementing the `ParsableAccessor` trait for accessing the
+    /// configuration at a certain position.
+    /// As `ParsableAccessor` is implemented by [`&str`] and [`String`], passing those directly
+    /// works.
+    ///
+    /// # Note
+    ///
+    /// Each time, [`Config::get`] is called, the `ParsableAccessor::parse()` function is called.
+    /// If that is a unbearable overhead (especially in cases where the accessor is hard-coded),
+    /// [`Config::get_with_accessor`] can be used to prevent that overhead.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use config_rs_ng::Config;
+    /// let config: Config = { //...
+    /// # unimplemented!()
+    /// };
+    ///
+    /// config.layers().get("foo")
+    ///     // ...
+    /// # ;
+    /// ```
+    pub fn get<A>(&self, accessor: A) -> Result<Option<&dyn ConfigElement>, ConfigError>
+    where
+        A: ParsableAccessor,
+    {
+        let accessor = accessor.parse()?;
+        self.get_with_accessor(accessor)
+    }
+
+    /// Get a "View" from the configuration
+    ///
+    /// The function works like [`Config::get`], except that it wraps the `&dyn ConfigElement` in a
+    /// `ConfigView` that also contains the description of the source of the configuration value.
+    pub fn get_view<A>(&self, accessor: A) -> Result<Option<ConfigView<'_>>, ConfigError>
+    where
+        A: ParsableAccessor,
+    {
+        let accessor = accessor.parse()?;
+        self.get_view_with_accessor(accessor)
+    }
+
+    pub fn get_as<A, T>(&self, accessor: A) -> Result<Option<&T>, ConfigError>
+    where
+        A: ParsableAccessor,
+        T: ConfigElement,
+    {
+        let accessor = accessor.parse()?;
+        self.get_with_accessor_as::<T>(accessor)
+    }
+
+    /// Access the configuration at a specific position
+    ///
+    /// See [`Layers::get`]
+    pub fn get_with_accessor(
+        &self,
+        mut accessor: Accessor,
+    ) -> Result<Option<&dyn ConfigElement>, ConfigError> {
+        for layer in self.0.iter().rev() {
+            if let Some(value) = layer.get(&mut accessor)? {
+                return Ok(Some(value));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Access the configuration at a specific position, and return the description of the value as
+    /// well
+    ///
+    /// See [`Layers::get_view`]
+    pub fn get_view_with_accessor(
+        &self,
+        mut accessor: Accessor,
+    ) -> Result<Option<ConfigView<'_>>, ConfigError> {
+        for layer in self.0.iter().rev() {
+            if let Some(view) = layer.get_with_description(&mut accessor)? {
+                return Ok(Some(view));
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub fn get_with_accessor_as<T>(&self, mut accessor: Accessor) -> Result<Option<&T>, ConfigError>
+    where
+        T: ConfigElement,
+    {
+        for layer in self.0.iter().rev() {
+            if let Some(value) = layer.get_as::<T>(&mut accessor)? {
+                return Ok(Some(value));
+            }
+        }
+
+        Ok(None)
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "async")]
 mod async_builder;
-#[cfg(not(feature = "async"))]
+#[cfg(feature = "async")]
+mod async_config;
 mod builder;
 #[allow(clippy::module_inception)]
 mod config;
@@ -8,12 +9,13 @@ mod error;
 
 #[cfg(feature = "async")]
 pub use crate::config::async_builder::*;
-#[cfg(not(feature = "async"))]
+#[cfg(feature = "async")]
+pub use crate::config::async_config::*;
 pub use crate::config::builder::*;
 pub use crate::config::config::*;
 pub use crate::config::error::*;
 
-#[cfg(all(test, not(feature = "async")))]
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,6 +6,7 @@ mod builder;
 #[allow(clippy::module_inception)]
 mod config;
 mod error;
+mod layers;
 
 #[cfg(feature = "async")]
 pub use crate::config::async_builder::*;
@@ -14,6 +15,7 @@ pub use crate::config::async_config::*;
 pub use crate::config::builder::*;
 pub use crate::config::config::*;
 pub use crate::config::error::*;
+pub use crate::config::layers::Layers;
 
 #[cfg(test)]
 mod tests {
@@ -59,7 +61,7 @@ mod tests {
 
         let c = Config::builder().load(Box::new(source)).build().unwrap();
 
-        let r = c.get("key");
+        let r = c.layers().get("key");
         assert!(r.is_ok());
         let r = r.unwrap();
         assert!(r.is_some());
@@ -94,7 +96,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let r = c.get("key1");
+        let r = c.layers().get("key1");
         assert!(r.is_ok());
         let r = r.unwrap();
         assert!(r.is_some());
@@ -102,7 +104,7 @@ mod tests {
         assert!(r.is_str());
         assert_eq!(r.as_str().unwrap(), "value2");
 
-        let r = c.get("key2");
+        let r = c.layers().get("key2");
         assert!(r.is_ok());
         let r = r.unwrap();
         assert!(r.is_some());
@@ -138,7 +140,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let r = c.get("key1");
+        let r = c.layers().get("key1");
         assert!(r.is_ok());
         let r = r.unwrap();
         assert!(r.is_some());
@@ -146,7 +148,7 @@ mod tests {
         assert!(r.is_str());
         assert_eq!(r.as_str().unwrap(), "value2");
 
-        let r = c.get("key2");
+        let r = c.layers().get("key2");
         assert!(r.is_ok());
         let r = r.unwrap();
         assert!(r.is_some());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,9 @@ pub use crate::accessor::AccessType;
 pub use crate::accessor::Accessor;
 pub use crate::accessor::ParsableAccessor;
 #[cfg(feature = "async")]
-pub use crate::config::AsyncConfigBuilder;
-#[cfg(feature = "async")]
 pub use crate::config::AsyncConfig;
+#[cfg(feature = "async")]
+pub use crate::config::AsyncConfigBuilder;
 pub use crate::config::Config;
 pub use crate::config::ConfigBuilder;
 pub use crate::description::ConfigSourceDescription;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,9 @@ pub use crate::accessor::Accessor;
 pub use crate::accessor::ParsableAccessor;
 #[cfg(feature = "async")]
 pub use crate::config::AsyncConfigBuilder;
+#[cfg(feature = "async")]
+pub use crate::config::AsyncConfig;
 pub use crate::config::Config;
-#[cfg(not(feature = "async"))]
 pub use crate::config::ConfigBuilder;
 pub use crate::description::ConfigSourceDescription;
 pub use crate::element::ConfigElement;

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -186,6 +186,7 @@ fn test_format_custom() {
     {
         // Lets get a serde_json::Value object by accessing "key1" from above
         if let Some(json_object) = config
+            .layers()
             .get_as::<_, serde_json::Value>("key1")
             .expect("Accessing configuration object")
         {
@@ -201,6 +202,7 @@ fn test_format_custom() {
         //
         // This value has shadowed the "key2" from the JSON part of our config object!
         if let Some(custom_object) = config
+            .layers()
             .get_as::<_, CustomValue>("key2")
             .expect("Accessing configuration object")
         {

--- a/tests/layers.rs
+++ b/tests/layers.rs
@@ -33,6 +33,7 @@ fn test_layers_simple() {
 
     {
         let value = config
+            .layers()
             .get("key1")
             .expect("Accessing configuration object")
             .expect("Finding 'key' in configuration object");
@@ -43,6 +44,7 @@ fn test_layers_simple() {
     }
     {
         let value = config
+            .layers()
             .get("key2")
             .expect("Accessing configuration object")
             .expect("Finding 'key' in configuration object");
@@ -53,6 +55,7 @@ fn test_layers_simple() {
     }
     {
         let value = config
+            .layers()
             .get("key3")
             .expect("Accessing configuration object")
             .expect("Finding 'key' in configuration object");

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -65,6 +65,7 @@ fn test_reloading() {
 
     fn assert_key_val(config: &Config, key: &str, val: &str) {
         let value = config
+            .layers()
             .get(key)
             .expect("Accessing configuration object")
             .expect(&format!("Finding '{}' in configuration object", key));
@@ -79,6 +80,7 @@ fn test_reloading() {
     assert_key_val(&config, "key3", "valueB");
     assert!({
         config
+            .layers()
             .get("key4")
             .expect("Accessing configuration object")
             .is_none()
@@ -91,6 +93,7 @@ fn test_reloading() {
     assert_key_val(&config, "key4", "valueC");
     assert!({
         config
+            .layers()
             .get("key3")
             .expect("Accessing configuration object")
             .is_none()


### PR DESCRIPTION
This PR changes the crate to have the sync interface always available and the async interface on demand, but enabling the async interface does not hide the sync one.

Also, the API surface was reduced using the `Layers` type. For more information, see the commit log.