### PR TITLE
Set RUSTUP_TOOLCHAIN in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ jobs:
           - stable
           - beta
           # - nightly
-
+    # required because we have a different toolchain than {{ matrix.rust }} in
+    # rust-toolchain.toml, which we use for the flake.nix
+    env:
+      RUSTUP_TOOLCHAIN: ${{ matrix.rust }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -58,6 +61,11 @@ jobs:
     name: format
     runs-on: ubuntu-latest
 
+    # required because we have a different toolchain than {{ matrix.rust }} in
+    # rust-toolchain.toml, which we use for the flake.nix
+    env:
+      RUSTUP_TOOLCHAIN: 1.60.0
+
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
@@ -78,6 +86,10 @@ jobs:
           - stable
           - beta
           # - nightly
+    # required because we have a different toolchain than {{ matrix.rust }} in
+    # rust-toolchain.toml, which we use for the flake.nix
+    env:
+      RUSTUP_TOOLCHAIN: ${{ matrix.rust }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -95,6 +107,10 @@ jobs:
   clippy:
     name: clippy
     runs-on: ubuntu-latest
+    # required because we have a different toolchain than {{ matrix.rust }} in
+    # rust-toolchain.toml, which we use for the flake.nix
+    env:
+      RUSTUP_TOOLCHAIN: 1.60.0
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master

--- a/.gitlint
+++ b/.gitlint
@@ -112,10 +112,10 @@ contrib=CC1, CC2
 # Use 'all' to ignore all rules
 # ignore=T1,body-min-length
 
-# [ignore-body-lines]
+[ignore-body-lines]
 # Ignore certain lines in a commit body that match a regex.
 # E.g. Ignore all lines that start with 'Co-Authored-By'
-# regex=^Co-Authored-By
+regex=^(Co-Authored-By|http)
 
 [ignore-by-author-name]
 # Ignore certain rules for commits of which the author name matches a regex


### PR DESCRIPTION
The problem here is that we are not actually using rust 1.60.0 due to the contents of rust-toolchain.toml file, which we need for the flake.nix infrastructure.

We are installing Rust 1.60.0, but 1.66 ends up being used anyway. This then conflicts with dtolnay/rust-toolchain's way to conditionally set CARGO_REGISTRIES_CRATES_IO_PROTOCOL: it checks if the toolchain being installed is 1.66 or 1.67 (which is not the case for you) and otherwise sets the flag. This assumes that if you're installing an old version you're using that old version, and there the flag will be ignored because not yet implemented. However you end up actually using rust 1.66 and thus the flag is read and breaks your CI because it's nightly only.

To fix the actual issue (running rust 1.66 instead of 1.60) we can either explicitly set the toolchain in the command (cargo +${{ matrix.rust }} check for each command) or set the RUSTUP_TOOLCHAIN environment variable to ${{ matrix.rust }}. Both will override your rust-toolchain.toml.

We opt for the latter here, for no particular reason.

Thanks to @SkiFire13, who helped solving this here:
    https://users.rust-lang.org/t/sparse-registry-breaking-my-ci-and-i-dont-understand-why/89976/