### PR TITLE
Make ConfigElementType::name() pub

### DIFF
--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -324,7 +324,7 @@ pub enum ConfigElementType {
 }
 
 impl ConfigElementType {
-    pub(crate) fn name(&self) -> &'static str {
+    pub fn name(&self) -> &'static str {
         match self {
             ConfigElementType::Null => "null",
             ConfigElementType::Bool => "bool",


### PR DESCRIPTION
This is a helper function only used in constructing error objects, make it pub so users can use it when implementing FromConfigElement.