### PR TITLE
Nested custom config types

### DIFF
--- a/config_rs_ng_derive/src/config_constructor.rs
+++ b/config_rs_ng_derive/src/config_constructor.rs
@@ -1,0 +1,78 @@
+use proc_macro::TokenStream as TS;
+use proc_macro2::Ident;
+use proc_macro2::TokenStream;
+use proc_macro_error::abort;
+use quote::TokenStreamExt;
+use syn::{parse_macro_input, DeriveInput, Type};
+
+enum FieldConstruction<'q> {
+    Named { name: Option<&'q Ident>, ty: &'q Type },
+}
+
+impl<'q> quote::ToTokens for FieldConstruction<'q> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            FieldConstruction::Named { name, ty } => {
+                tokens.append_all({
+                    quote::quote! {
+                        #name: {
+                            let element: &dyn config_rs_ng::ConfigElement = layers
+                                .get(stringify!(#name))
+                                .map_err(config_rs_ng::FromConfigElementError::from)?
+                                .ok_or_else(|| {
+                                    config_rs_ng::FromConfigElementError::NoElement {
+                                        name: stringify!(#name).to_string(),
+                                        ty: stringify!(#ty).to_string(),
+                                    }
+                                })?;
+
+                            <#ty as config_rs_ng::FromConfigElement>::from_config_element(element)?
+                        },
+                    }
+                });
+            }
+        };
+    }
+}
+
+pub fn derive_config_constructor_impl(input: TS) -> TS {
+    let input = parse_macro_input!(input as DeriveInput);
+    let ident = &input.ident;
+
+    let construction: Vec<FieldConstruction> = if let syn::Data::Struct(data) = &input.data {
+        match &data.fields {
+            syn::Fields::Named(fields) => fields
+                .named
+                .iter()
+                .map(|field| FieldConstruction::Named {
+                    name: field.ident.as_ref(),
+                    ty: &field.ty,
+                })
+                .collect::<Vec<FieldConstruction>>(),
+            syn::Fields::Unnamed(_) => abort!(ident, "Unnamed fields are not supported"),
+            syn::Fields::Unit => abort!(
+                ident,
+                "Unit structs are not supported as they cannot be represented"
+            )
+        }
+    } else {
+        abort!(
+            ident,
+            "Currently, only structs are supported"
+        )
+    };
+
+    let expanded = quote::quote! {
+        impl config_rs_ng::ConfigConstructor for #ident {
+            type Error = config_rs_ng::FromConfigElementError;
+
+            fn construct_from(layers: &config_rs_ng::Layers) -> std::result::Result<Self, Self::Error> {
+                Ok(Self {
+                    #( #construction )*
+                })
+            }
+        }
+    };
+
+    TS::from(expanded)
+}

--- a/config_rs_ng_derive/src/from_config_element.rs
+++ b/config_rs_ng_derive/src/from_config_element.rs
@@ -1,0 +1,84 @@
+use proc_macro::TokenStream as TS;
+use proc_macro2::Ident;
+use proc_macro2::TokenStream;
+use proc_macro_error::abort;
+use quote::TokenStreamExt;
+use syn::{parse_macro_input, DeriveInput, Type};
+
+enum FieldConstruction<'q> {
+    Named { name: Option<&'q Ident>, ty: &'q Type },
+}
+
+impl<'q> quote::ToTokens for FieldConstruction<'q> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            FieldConstruction::Named { name, ty } => {
+                tokens.append_all({
+                    quote::quote! {
+                        #name: {
+                            map.get(stringify!(#name))
+                                .ok_or_else(|| config_rs_ng::FromConfigElementError::NoElement {
+                                    name: stringify!(#name).to_string(),
+                                    ty: stringify!(#ty).to_string(),
+                                })
+                            .and_then(#ty::from_config_element)?
+                        },
+                    }
+                });
+            }
+        };
+    }
+}
+
+
+pub fn derive_from_config_element_impl(input: TS) -> TS {
+    let input = parse_macro_input!(input as DeriveInput);
+    let ident = &input.ident;
+
+    let construction: Vec<FieldConstruction> = if let syn::Data::Struct(data) = &input.data {
+        match &data.fields {
+            syn::Fields::Named(fields) => fields
+                .named
+                .iter()
+                .map(|field| FieldConstruction::Named {
+                    name: field.ident.as_ref(),
+                    ty: &field.ty,
+                })
+                .collect::<Vec<FieldConstruction>>(),
+            syn::Fields::Unnamed(_) => abort!(ident, "Unnamed fields are not supported"),
+            syn::Fields::Unit => abort!(
+                ident,
+                "Unit structs are not supported as they cannot be represented"
+            )
+        }
+    } else {
+        abort!(
+            ident,
+            "Currently, only structs are supported"
+        )
+    };
+
+    let expanded = quote::quote! {
+        impl config_rs_ng::FromConfigElement for #ident {
+            type Error = config_rs_ng::FromConfigElementError;
+
+            fn from_config_element(element: &dyn config_rs_ng::ConfigElement) -> Result<Self, Self::Error> {
+                let map = element.as_map().ok_or_else(|| {
+                    let found = element.get_type().name();
+                    config_rs_ng::FromConfigElementError::TypeError {
+                        expected: "map",
+                        found,
+                    }
+                })?;
+
+                Ok({
+                    Self {
+                        #( #construction )*
+                    }
+                })
+            }
+        }
+    };
+
+    TS::from(expanded)
+}

--- a/config_rs_ng_derive/src/lib.rs
+++ b/config_rs_ng_derive/src/lib.rs
@@ -1,79 +1,8 @@
 use proc_macro::TokenStream as TS;
-use proc_macro2::Ident;
-use proc_macro2::TokenStream;
-use proc_macro_error::abort;
-use quote::TokenStreamExt;
-use syn::{parse_macro_input, DeriveInput, Type};
 
-enum FieldConstruction<'q> {
-    Named { name: Option<&'q Ident>, ty: &'q Type },
-}
-
-impl<'q> quote::ToTokens for FieldConstruction<'q> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        match self {
-            FieldConstruction::Named { name, ty } => {
-                tokens.append_all({
-                    quote::quote! {
-                        #name: {
-                            let element: &dyn config_rs_ng::ConfigElement = layers
-                                .get(stringify!(#name))
-                                .map_err(config_rs_ng::FromConfigElementError::from)?
-                                .ok_or_else(|| {
-                                    config_rs_ng::FromConfigElementError::NoElement {
-                                        name: stringify!(#name).to_string(),
-                                        ty: stringify!(#ty).to_string(),
-                                    }
-                                })?;
-
-                            <#ty as config_rs_ng::FromConfigElement>::from_config_element(element)?
-                        },
-                    }
-                });
-            }
-        };
-    }
-}
+mod config_constructor;
 
 #[proc_macro_derive(ConfigConstructor)]
 pub fn derive_config_constructor(input: TS) -> TS {
-    let input = parse_macro_input!(input as DeriveInput);
-    let ident = &input.ident;
-
-    let construction: Vec<FieldConstruction> = if let syn::Data::Struct(data) = &input.data {
-        match &data.fields {
-            syn::Fields::Named(fields) => fields
-                .named
-                .iter()
-                .map(|field| FieldConstruction::Named {
-                    name: field.ident.as_ref(),
-                    ty: &field.ty,
-                })
-                .collect::<Vec<FieldConstruction>>(),
-            syn::Fields::Unnamed(_) => abort!(ident, "Unnamed fields are not supported"),
-            syn::Fields::Unit => abort!(
-                ident,
-                "Unit structs are not supported as they cannot be represented"
-            )
-        }
-    } else {
-        abort!(
-            ident,
-            "Currently, only structs are supported"
-        )
-    };
-
-    let expanded = quote::quote! {
-        impl config_rs_ng::ConfigConstructor for #ident {
-            type Error = config_rs_ng::FromConfigElementError;
-
-            fn construct_from(layers: &config_rs_ng::Layers) -> std::result::Result<Self, Self::Error> {
-                Ok(Self {
-                    #( #construction )*
-                })
-            }
-        }
-    };
-
-    TS::from(expanded)
+    crate::config_constructor::derive_config_constructor_impl(input)
 }

--- a/config_rs_ng_derive/src/lib.rs
+++ b/config_rs_ng_derive/src/lib.rs
@@ -1,8 +1,15 @@
 use proc_macro::TokenStream as TS;
 
 mod config_constructor;
+mod from_config_element;
 
 #[proc_macro_derive(ConfigConstructor)]
 pub fn derive_config_constructor(input: TS) -> TS {
     crate::config_constructor::derive_config_constructor_impl(input)
 }
+
+#[proc_macro_derive(FromConfigElement)]
+pub fn derive_from_config_element(input: TS) -> TS {
+    crate::from_config_element::derive_from_config_element_impl(input)
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod object;
 mod source;
 
 pub use config_rs_ng_derive::ConfigConstructor;
+pub use config_rs_ng_derive::FromConfigElement;
 
 pub use crate::accessor::AccessType;
 pub use crate::accessor::Accessor;

--- a/tests/proc_macro.rs
+++ b/tests/proc_macro.rs
@@ -5,7 +5,7 @@ use config_rs_ng::ConfigConstructor;
 use config_rs_ng::StringSource;
 use config_rs_ng::TomlFormatParser;
 
-#[derive(Debug, config_rs_ng::ConfigConstructor)]
+#[derive(Debug, config_rs_ng::ConfigConstructor, config_rs_ng::FromConfigElement)]
 struct SimpleConfig {
     s: String,
 }
@@ -32,32 +32,6 @@ struct OtherConfig {
     optional: Option<i32>,
 
     simple: SimpleConfig,
-}
-
-impl config_rs_ng::FromConfigElement for SimpleConfig {
-    type Error = config_rs_ng::FromConfigElementError;
-
-    fn from_config_element(element: &dyn config_rs_ng::ConfigElement) -> Result<Self, Self::Error> {
-        let map = element.as_map().ok_or_else(|| {
-            let found = element.get_type().name();
-            config_rs_ng::FromConfigElementError::TypeError {
-                expected: "map",
-                found,
-            }
-        })?;
-
-        Ok({
-            Self {
-                s: map
-                    .get("s")
-                    .ok_or_else(|| config_rs_ng::FromConfigElementError::NoElement {
-                        name: "s".to_string(),
-                        ty: "String".to_string(),
-                    })
-                    .and_then(String::from_config_element)?
-            }
-        })
-    }
 }
 
 const OTHER_CONFIG: &str = r#"

--- a/tests/proc_macro.rs
+++ b/tests/proc_macro.rs
@@ -26,3 +26,56 @@ fn test() {
     let simple = SimpleConfig::construct_from(config.layers()).unwrap();
     assert_eq!(simple.s, "foo");
 }
+
+#[derive(Debug, config_rs_ng::ConfigConstructor)]
+struct OtherConfig {
+    optional: Option<i32>,
+
+    simple: SimpleConfig,
+}
+
+impl config_rs_ng::FromConfigElement for SimpleConfig {
+    type Error = config_rs_ng::FromConfigElementError;
+
+    fn from_config_element(element: &dyn config_rs_ng::ConfigElement) -> Result<Self, Self::Error> {
+        let map = element.as_map().ok_or_else(|| {
+            let found = element.get_type().name();
+            config_rs_ng::FromConfigElementError::TypeError {
+                expected: "map",
+                found,
+            }
+        })?;
+
+        Ok({
+            Self {
+                s: map
+                    .get("s")
+                    .ok_or_else(|| config_rs_ng::FromConfigElementError::NoElement {
+                        name: "s".to_string(),
+                        ty: "String".to_string(),
+                    })
+                    .and_then(String::from_config_element)?
+            }
+        })
+    }
+}
+
+const OTHER_CONFIG: &str = r#"
+    optional = 12
+    [simple]
+    s = "bar"
+"#;
+
+#[test]
+fn test_config() {
+    let config = Config::builder()
+        .load(Box::new(
+            StringSource::<TomlFormatParser>::new(OTHER_CONFIG.to_string()).unwrap(),
+        ))
+        .build()
+        .unwrap();
+
+    let other = OtherConfig::construct_from(config.layers()).unwrap();
+    assert_eq!(other.optional, Some(12));
+    assert_eq!(other.simple.s, "bar");
+}


### PR DESCRIPTION
As of current master, custom configuration structs cannot be nested easily. One must implement `FromConfigElement` on the inner struct.

With this, we introduce a derive macro for that trait, to make it less of a burden for the user. A testcase is added for this.