### PR TITLE
Make error types non_exhaustive

### DIFF
--- a/src/config/construct.rs
+++ b/src/config/construct.rs
@@ -23,6 +23,7 @@ where
 }
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum FromConfigElementError {
     #[error("Type error. Expected '{expected}', got '{found}'")]
     TypeError {

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ConfigError {
     #[error("Accessor parser error")]
     AccessorParseError(#[from] crate::accessor::AccessorParseError),

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -22,6 +22,7 @@ pub trait ConfigSource: std::fmt::Debug {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum SourceError {
     #[error("IO Error")]
     Io(#[from] std::io::Error),


### PR DESCRIPTION
We cannot be sure that these error types are exhaustive. Thus, do mark them as non_exhaustive for now.