### PR TITLE
Custom error variants

### DIFF
--- a/src/config/construct.rs
+++ b/src/config/construct.rs
@@ -24,6 +24,9 @@ where
 
 #[derive(Debug, thiserror::Error)]
 pub enum FromConfigElementError {
+    #[error(transparent)]
+    Custom(#[from] Box<dyn std::error::Error>),
+
     #[error("Type error. Expected '{expected}', got '{found}'")]
     TypeError {
         expected: &'static str,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -23,6 +23,9 @@ pub trait ConfigSource: std::fmt::Debug {
 
 #[derive(Debug, thiserror::Error)]
 pub enum SourceError {
+    #[error(transparent)]
+    Custom(#[from] Box<dyn std::error::Error>),
+
     #[error("IO Error")]
     Io(#[from] std::io::Error),
 


### PR DESCRIPTION
Some of our error types must be able to be constructed by a user of the crate. Because we cannot foresee how users might want to structure their error types, we add a `Custom` variant to these types, so that users can return custom error types as they see fit.