### PR TITLE
Change dependabot to run monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly


### PR DESCRIPTION
This does reduce dependabot intervals from weekly to monthly because if there's little progress in the repository, there's no point in updating dependencies every week.