### PR TITLE
Make cargo-check run with --locked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: swatinem/rust-cache@v2
       - name: cargo-check
-        run: cargo check --tests --examples
+        run: cargo check --locked --tests --examples
       - name: cargo-check for async
-        run: cargo check --tests --examples --features async
+        run: cargo check --locked --tests --examples --features async
 
   deny:
     name: deny

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.12",
 ]
 
 [[package]]


### PR DESCRIPTION
This way CI fails if the lockfile is not up to date.